### PR TITLE
Feature/#6 - PR open, synchronize, closed시 Gradle Build Test Job 도입 

### DIFF
--- a/.github/workflows/pull-request-gradle-build-test.yml
+++ b/.github/workflows/pull-request-gradle-build-test.yml
@@ -1,0 +1,41 @@
+name : Pull Request Gradle Build Test
+
+on:
+  pull_request:
+    types: [opened, synchronize, closed]
+
+permissions: read-all
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v3.0.2
+
+      - uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            application:
+            - 'build.gradle.kts'
+            - '**/src/**'
+
+      - name: JDK 설치
+        if: steps.changes.outputs.application == 'true'
+        uses: actions/setup-java@v3
+        with:
+          distribution: zulu
+          java-version: 17
+          cache: 'gradle'
+
+      - name: gradlew 권한 부여
+        run: chmod +x ./gradlew
+        
+      - name: Gradle Build
+        if: steps.changes.outputs.application == 'true'
+        run: |
+          ./gradlew build --no-build-cache


### PR DESCRIPTION
PR을 open, synchronize, closed 할 때마다 빌드하기 위한 github workflows 코드 작성


## 📒 Issue
#6 : PR open, synchronize, closed시 Gradle Build Test Job 도입 
개발 과정에서, PR을 날리거나, PR Open 이후 commit을 추가할 때마다 매번 잊지않고, 테스트를 돌리는 것은 쉽지 않습니다.
자동 빌드 테스트를 통해 Pull Request 코드들에 대한 테스트를 자동으로 진행하고 편하게 결과를 받아볼 수 있습니다.


## 🎯 어떤 작업을 했는지
Github Workflows 코드를 추가했습니다.


## 📜 자세한 설명
build는 ubuntu에서 진행되고, PR이 열릴때, 닫힐 때 (Merge 포함), Open 이후 commit이 새로 쌓일 때 진행됩니다.
각 step들이 어떤 역할을 하는지 한글 이름을 붙여 두었습니다.

<br>

쓸대없는 빌드는 생산성을 낮추고, 무료 Github Actions 시간을 소모하기 때문에, build.gradle 파일과 src 디렉토리 내부의 파일들이 변할때만 빌드를 진행하도록 했습니다.
```
     - uses: dorny/paths-filter@v2
        id: changes
        with:
          filters: |
            application:
            - 'build.gradle.kts'
            - '**/src/**'
```

<br>

## 🌍 영향범위 (모듈)

전 모듈에 영향

