### PR TITLE
[Feature] Goal API 작성 #27

### DIFF
--- a/application/api/src/main/kotlin/io/raemian/api/goal/CreateGoalResponse.kt
+++ b/application/api/src/main/kotlin/io/raemian/api/goal/CreateGoalResponse.kt
@@ -1,0 +1,5 @@
+package io.raemian.api.goal
+
+data class CreateGoalResponse(
+    val id: Long,
+)

--- a/application/api/src/main/kotlin/io/raemian/api/goal/GoalService.kt
+++ b/application/api/src/main/kotlin/io/raemian/api/goal/GoalService.kt
@@ -1,21 +1,29 @@
 package io.raemian.api.goal
 
+import io.raemian.api.goal.controller.request.CreateGoalRequest
+import io.raemian.api.goal.controller.request.DeleteGoalRequest
 import io.raemian.api.goal.controller.response.GoalResponse
 import io.raemian.api.goal.controller.response.GoalsResponse
-import io.raemian.api.support.SecurityUtil
+import io.raemian.api.sticker.StickerService
+import io.raemian.api.support.RaemianLocalDate
+import io.raemian.api.tag.TagService
+import io.raemian.api.user.UserService
+import io.raemian.storage.db.core.goal.Goal
 import io.raemian.storage.db.core.goal.GoalRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 @Service
 class GoalService(
+    private val userService: UserService,
+    private val stickerService: StickerService,
+    private val tagService: TagService,
     private val goalRepository: GoalRepository,
 ) {
 
     @Transactional(readOnly = true)
-    fun findAllByUserId(): GoalsResponse {
-        val currentUserId = SecurityUtil.currentUserId()
-        val goals = goalRepository.findAllByUserId(currentUserId)
+    fun findAllByUserId(userId: Long): GoalsResponse {
+        val goals = goalRepository.findAllByUserId(userId)
         return GoalsResponse(goals)
     }
 
@@ -23,5 +31,32 @@ class GoalService(
     fun getById(id: Long): GoalResponse {
         val goal = goalRepository.getById(id)
         return GoalResponse(goal)
+    }
+
+    @Transactional
+    fun create(userId: Long, createGoalRequest: CreateGoalRequest): CreateGoalResponse {
+        val (title, yearOfDeadline, monthOfDeadLine, stickerId, tagId, description) = createGoalRequest
+
+        val deadline = RaemianLocalDate.of(yearOfDeadline, monthOfDeadLine)
+        val sticker = stickerService.getById(stickerId)
+        val tag = tagService.getById(tagId)
+        val user = userService.getById(userId)
+
+        val goal = Goal(user, title, deadline, sticker, tag, description, emptyList())
+        val savedGoal = goalRepository.save(goal)
+        return CreateGoalResponse(savedGoal.id!!)
+    }
+
+    @Transactional
+    fun delete(userId: Long, deleteGoalRequest: DeleteGoalRequest) {
+        val goal = goalRepository.getById(deleteGoalRequest.goalId)
+        validateGoalIsUsers(userId, goal)
+        goalRepository.delete(goal)
+    }
+
+    private fun validateGoalIsUsers(userId: Long, goal: Goal) {
+        if (userId != goal.user.id) {
+            throw SecurityException()
+        }
     }
 }

--- a/application/api/src/main/kotlin/io/raemian/api/goal/GoalService.kt
+++ b/application/api/src/main/kotlin/io/raemian/api/goal/GoalService.kt
@@ -42,7 +42,7 @@ class GoalService(
         val tag = tagService.getById(tagId)
         val user = userService.getById(userId)
 
-        val goal = Goal(user, title, deadline, sticker, tag, description, emptyList())
+        val goal = Goal(user, title, deadline, sticker, tag, description!!, emptyList())
         val savedGoal = goalRepository.save(goal)
         return CreateGoalResponse(savedGoal.id!!)
     }

--- a/application/api/src/main/kotlin/io/raemian/api/goal/GoalService.kt
+++ b/application/api/src/main/kotlin/io/raemian/api/goal/GoalService.kt
@@ -1,0 +1,27 @@
+package io.raemian.api.goal
+
+import io.raemian.api.goal.controller.response.GoalResponse
+import io.raemian.api.goal.controller.response.GoalsResponse
+import io.raemian.api.support.SecurityUtil
+import io.raemian.storage.db.core.goal.GoalRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class GoalService(
+    private val goalRepository: GoalRepository,
+) {
+
+    @Transactional(readOnly = true)
+    fun findAllByUserId(): GoalsResponse {
+        val currentUserId = SecurityUtil.currentUserId()
+        val goals = goalRepository.findAllByUserId(currentUserId)
+        return GoalsResponse(goals)
+    }
+
+    @Transactional(readOnly = true)
+    fun getById(id: Long): GoalResponse {
+        val goal = goalRepository.getById(id)
+        return GoalResponse(goal)
+    }
+}

--- a/application/api/src/main/kotlin/io/raemian/api/goal/controller/GoalController.kt
+++ b/application/api/src/main/kotlin/io/raemian/api/goal/controller/GoalController.kt
@@ -40,7 +40,6 @@ class GoalController(
     ): ResponseEntity<GoalResponse> =
         ResponseEntity.ok(goalService.getById(goalId))
 
-
     @PostMapping
     fun create(
         @AuthenticationPrincipal currentUser: CurrentUser,

--- a/application/api/src/main/kotlin/io/raemian/api/goal/controller/GoalController.kt
+++ b/application/api/src/main/kotlin/io/raemian/api/goal/controller/GoalController.kt
@@ -1,0 +1,63 @@
+package io.raemian.api.goal.controller
+
+import io.raemian.api.auth.domain.CurrentUser
+import io.raemian.api.goal.CreateGoalResponse
+import io.raemian.api.goal.GoalService
+import io.raemian.api.goal.controller.request.CreateGoalRequest
+import io.raemian.api.goal.controller.request.DeleteGoalRequest
+import io.raemian.api.goal.controller.response.GoalResponse
+import io.raemian.api.goal.controller.response.GoalsResponse
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.net.URI
+
+fun String.toUri(): URI = URI.create(this)
+
+@RestController
+@RequestMapping("/goal")
+class GoalController(
+    private val goalService: GoalService,
+) {
+
+    @GetMapping
+    fun findAllByUserId(
+        @AuthenticationPrincipal currentUser: CurrentUser,
+    ): ResponseEntity<GoalsResponse> {
+        val response = goalService.findAllByUserId(currentUser.id)
+        return ResponseEntity.ok(response)
+    }
+
+    @GetMapping("/{goal_id}")
+    fun getByUserId(
+        @PathVariable("goal_id") goalId: Long,
+    ): ResponseEntity<GoalResponse> =
+        ResponseEntity.ok(goalService.getById(goalId))
+
+
+    @PostMapping
+    fun create(
+        @AuthenticationPrincipal currentUser: CurrentUser,
+        @RequestBody createGoalRequest: CreateGoalRequest,
+    ): ResponseEntity<CreateGoalResponse> {
+        val response = goalService.create(currentUser.id, createGoalRequest)
+        return ResponseEntity
+            .created("/goal/${response.id}".toUri())
+            .body(response)
+    }
+
+    @DeleteMapping
+    fun delete(
+        @AuthenticationPrincipal currentUser: CurrentUser,
+        @RequestBody deleteGoalRequest: DeleteGoalRequest,
+    ): ResponseEntity<Unit> {
+        goalService.delete(currentUser.id, deleteGoalRequest)
+        return ResponseEntity.ok().build()
+    }
+}

--- a/application/api/src/main/kotlin/io/raemian/api/goal/controller/GoalController.kt
+++ b/application/api/src/main/kotlin/io/raemian/api/goal/controller/GoalController.kt
@@ -34,9 +34,9 @@ class GoalController(
         return ResponseEntity.ok(response)
     }
 
-    @GetMapping("/{goal_id}")
+    @GetMapping("/{goalId}")
     fun getByUserId(
-        @PathVariable("goal_id") goalId: Long,
+        @PathVariable("goalId") goalId: Long,
     ): ResponseEntity<GoalResponse> =
         ResponseEntity.ok(goalService.getById(goalId))
 

--- a/application/api/src/main/kotlin/io/raemian/api/goal/controller/GoalController.kt
+++ b/application/api/src/main/kotlin/io/raemian/api/goal/controller/GoalController.kt
@@ -57,6 +57,6 @@ class GoalController(
         @RequestBody deleteGoalRequest: DeleteGoalRequest,
     ): ResponseEntity<Unit> {
         goalService.delete(currentUser.id, deleteGoalRequest)
-        return ResponseEntity.ok().build()
+        return ResponseEntity.noContent().build()
     }
 }

--- a/application/api/src/main/kotlin/io/raemian/api/goal/controller/request/CreateGoalRequest.kt
+++ b/application/api/src/main/kotlin/io/raemian/api/goal/controller/request/CreateGoalRequest.kt
@@ -1,0 +1,10 @@
+package io.raemian.api.goal.controller.request
+
+data class CreateGoalRequest(
+    val title: String,
+    val yearOfDeadline: String,
+    val monthOfDeadLine: String,
+    val stickerId: Long,
+    val tagId: Long,
+    val description: String?,
+)

--- a/application/api/src/main/kotlin/io/raemian/api/goal/controller/request/CreateGoalRequest.kt
+++ b/application/api/src/main/kotlin/io/raemian/api/goal/controller/request/CreateGoalRequest.kt
@@ -6,5 +6,5 @@ data class CreateGoalRequest(
     val monthOfDeadLine: String,
     val stickerId: Long,
     val tagId: Long,
-    val description: String?,
+    val description: String? = "",
 )

--- a/application/api/src/main/kotlin/io/raemian/api/goal/controller/request/DeleteGoalRequest.kt
+++ b/application/api/src/main/kotlin/io/raemian/api/goal/controller/request/DeleteGoalRequest.kt
@@ -1,0 +1,5 @@
+package io.raemian.api.goal.controller.request
+
+class DeleteGoalRequest(
+    val goalId: Long,
+)

--- a/application/api/src/main/kotlin/io/raemian/api/goal/controller/response/GoalResponse.kt
+++ b/application/api/src/main/kotlin/io/raemian/api/goal/controller/response/GoalResponse.kt
@@ -1,0 +1,41 @@
+package io.raemian.api.goal.controller.response
+
+import io.raemian.storage.db.core.goal.Goal
+import io.raemian.storage.db.core.sticker.StickerImage
+import io.raemian.storage.db.core.tag.Tag
+import io.raemian.storage.db.core.task.Task
+import java.time.LocalDate
+
+data class GoalResponse(
+    val title: String,
+    val deadline: LocalDate,
+    val sticker: StickerImage,
+    val tagInfo: TagInfo,
+    val tasks: List<TaskInfo>,
+) {
+
+    constructor(goal: Goal) : this(
+        goal.title,
+        goal.deadline,
+        goal.sticker.stickerImage,
+        TagInfo(goal.tag),
+        goal.tasks.map(::TaskInfo),
+    )
+
+    data class TagInfo(
+        val tagId: Long?,
+        val tagContent: String,
+    ) {
+
+        constructor(tag: Tag) : this(tag.id, tag.content)
+    }
+
+    data class TaskInfo(
+        val taskId: Long?,
+        val isTaskDone: Boolean,
+        val taskDescription: String,
+    ) {
+
+        constructor(task: Task) : this(task.id, task.isDone, task.description)
+    }
+}

--- a/application/api/src/main/kotlin/io/raemian/api/goal/controller/response/GoalsResponse.kt
+++ b/application/api/src/main/kotlin/io/raemian/api/goal/controller/response/GoalsResponse.kt
@@ -10,8 +10,7 @@ data class GoalsResponse(
 
     constructor(goals: List<Goal>) : this(
         Goals(
-            goals.map(::GoalInfo)
-                .toList()),
+            goals.map(::GoalInfo)),
     )
 
     data class GoalInfo(
@@ -20,16 +19,16 @@ data class GoalsResponse(
         val deadline: LocalDate,
         val sticker: StickerImage,
         val tagContent: String,
-        val description: String,
+        val description: String? = "",
     ) {
 
         constructor(goal: Goal) : this(
-            goal.id,
-            goal.title,
-            goal.deadline,
-            goal.sticker.stickerImage,
-            goal.tag.content,
-            goal.description,
+            id = goal.id,
+            title = goal.title,
+            deadline = goal.deadline,
+            sticker = goal.sticker.stickerImage,
+            tagContent = goal.tag.content,
+            description = goal.description,
         )
     }
 

--- a/application/api/src/main/kotlin/io/raemian/api/goal/controller/response/GoalsResponse.kt
+++ b/application/api/src/main/kotlin/io/raemian/api/goal/controller/response/GoalsResponse.kt
@@ -10,7 +10,8 @@ data class GoalsResponse(
 
     constructor(goals: List<Goal>) : this(
         Goals(
-            goals.map(::GoalInfo)),
+            goals.map(::GoalInfo),
+        ),
     )
 
     data class GoalInfo(

--- a/application/api/src/main/kotlin/io/raemian/api/goal/controller/response/GoalsResponse.kt
+++ b/application/api/src/main/kotlin/io/raemian/api/goal/controller/response/GoalsResponse.kt
@@ -1,0 +1,39 @@
+package io.raemian.api.goal.controller.response
+
+import io.raemian.storage.db.core.goal.Goal
+import io.raemian.storage.db.core.sticker.StickerImage
+import java.time.LocalDate
+
+data class GoalsResponse(
+    val goals: Goals,
+) {
+
+    constructor(goals: List<Goal>) : this(
+        Goals(
+            goals.map(::GoalInfo)
+                .toList()),
+    )
+
+    data class GoalInfo(
+        val id: Long?,
+        val title: String,
+        val deadline: LocalDate,
+        val sticker: StickerImage,
+        val tagContent: String,
+        val description: String,
+    ) {
+
+        constructor(goal: Goal) : this(
+            goal.id,
+            goal.title,
+            goal.deadline,
+            goal.sticker.stickerImage,
+            goal.tag.content,
+            goal.description,
+        )
+    }
+
+    data class Goals(
+        val goalInfos: List<GoalInfo>,
+    )
+}

--- a/application/api/src/main/kotlin/io/raemian/api/sticker/StickerService.kt
+++ b/application/api/src/main/kotlin/io/raemian/api/sticker/StickerService.kt
@@ -1,6 +1,7 @@
 package io.raemian.api.sticker
 
 import io.raemian.api.sticker.controller.response.StickerResponse
+import io.raemian.storage.db.core.sticker.Sticker
 import io.raemian.storage.db.core.sticker.StickerRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -14,5 +15,10 @@ class StickerService(
     fun findAll(): List<StickerResponse> {
         return stickerRepository.findAll()
             .map(::StickerResponse)
+    }
+
+    @Transactional(readOnly = true)
+    fun getById(id: Long): Sticker {
+        return stickerRepository.getById(id)
     }
 }

--- a/application/api/src/main/kotlin/io/raemian/api/support/RaemianLocalDate.kt
+++ b/application/api/src/main/kotlin/io/raemian/api/support/RaemianLocalDate.kt
@@ -1,0 +1,38 @@
+package io.raemian.api.support
+
+import java.time.LocalDate
+import java.time.Month
+import java.time.Year
+
+object RaemianLocalDate {
+
+    private const val DAY_OF_MONTH = 1
+
+    fun of(year: String, month: String): LocalDate {
+        val parsedYear = parseYear(year)
+        val parsedMonth = parseMonth(month)
+        return LocalDate.of(parsedYear, parsedMonth, DAY_OF_MONTH)
+    }
+
+    private fun parseYear(year: String): Int {
+        validateYearFormat(year)
+        return year.toInt()
+    }
+
+    private fun validateYearFormat(year: String) {
+        runCatching {
+            Year.parse(year)
+        }.onFailure {
+            throw IllegalArgumentException()
+        }
+    }
+
+    private fun parseMonth(month: String): Month {
+        val result = runCatching {
+            Month.of(month.toInt())
+        }
+
+        return result.getOrNull()
+            ?: throw IllegalArgumentException()
+    }
+}

--- a/application/api/src/main/kotlin/io/raemian/api/support/SecurityUtil.kt
+++ b/application/api/src/main/kotlin/io/raemian/api/support/SecurityUtil.kt
@@ -5,7 +5,7 @@ import org.springframework.security.core.context.SecurityContextHolder
 
 object SecurityUtil {
     // SecurityContext 에 유저 정보가 저장되는 시점
-    fun currentMemberId(): Long {
+    fun currentUserId(): Long {
         val authentication: Authentication? = SecurityContextHolder.getContext().authentication
         if (authentication == null || authentication.name == null) {
             throw RuntimeException("Security Context 에 인증 정보가 없습니다.")

--- a/application/api/src/main/kotlin/io/raemian/api/tag/TagService.kt
+++ b/application/api/src/main/kotlin/io/raemian/api/tag/TagService.kt
@@ -1,6 +1,7 @@
 package io.raemian.api.tag
 
 import io.raemian.api.tag.controller.response.TagResponse
+import io.raemian.storage.db.core.tag.Tag
 import io.raemian.storage.db.core.tag.TagRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -14,5 +15,10 @@ class TagService(
     fun findAll(): List<TagResponse> {
         return tagRepository.findAll()
             .map(::TagResponse)
+    }
+
+    @Transactional(readOnly = true)
+    fun getById(id: Long): Tag {
+        return tagRepository.getById(id)
     }
 }

--- a/application/api/src/main/kotlin/io/raemian/api/user/UserService.kt
+++ b/application/api/src/main/kotlin/io/raemian/api/user/UserService.kt
@@ -1,0 +1,17 @@
+package io.raemian.api.user
+
+import io.raemian.storage.db.core.user.User
+import io.raemian.storage.db.core.user.UserRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class UserService(
+    private val userRepository: UserRepository,
+) {
+
+    @Transactional(readOnly = true)
+    fun getById(userId: Long): User {
+        return userRepository.getById(userId)
+    }
+}

--- a/application/api/src/test/kotlin/io/raemian/api/integration/goal/GoalServiceTest.kt
+++ b/application/api/src/test/kotlin/io/raemian/api/integration/goal/GoalServiceTest.kt
@@ -1,0 +1,127 @@
+package io.raemian.api.integration.goal
+
+import io.raemian.api.goal.GoalService
+import io.raemian.storage.db.core.goal.Goal
+import io.raemian.storage.db.core.goal.GoalRepository
+import io.raemian.storage.db.core.sticker.Sticker
+import io.raemian.storage.db.core.sticker.StickerImage
+import io.raemian.storage.db.core.sticker.StickerRepository
+import io.raemian.storage.db.core.tag.Tag
+import io.raemian.storage.db.core.tag.TagRepository
+import io.raemian.storage.db.core.user.Authority
+import io.raemian.storage.db.core.user.User
+import io.raemian.storage.db.core.user.UserRepository
+import io.raemian.storage.db.core.user.enums.OAuthProvider
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatCode
+import org.junit.jupiter.api.Assertions.assertAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.function.Executable
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+
+@SpringBootTest
+class GoalServiceTest {
+
+    companion object {
+        val USER_FIXTURE = User(
+            "dfghcvb111@naver.com",
+            "binaryHoHo",
+            "binaryHoHoHo",
+            LocalDate.MIN,
+            OAuthProvider.NAVER,
+            Authority.ROLE_USER,
+        )
+
+        val STICKER_FIXTURE = Sticker("sticker", StickerImage("image yeah"))
+        val TAG_FIXTURE = Tag("꿈")
+    }
+
+    @Autowired
+    private lateinit var goalService: GoalService
+
+    @Autowired
+    private lateinit var goalRepository: GoalRepository
+
+    @Autowired
+    private lateinit var userRepository: UserRepository
+
+    @Autowired
+    private lateinit var stickerRepository: StickerRepository
+
+    @Autowired
+    private lateinit var tagRepository: TagRepository
+
+    @BeforeEach
+    fun saveEntities() {
+        userRepository.save(USER_FIXTURE)
+        stickerRepository.save(STICKER_FIXTURE)
+        tagRepository.save(TAG_FIXTURE)
+    }
+
+    @Test
+    @DisplayName("Goal ID를 통해 Goal을 조회 할 수 있다.")
+    @Transactional
+    fun getByIdTest() {
+        // given
+        val goal = Goal(
+            USER_FIXTURE,
+            "짱이 될거야",
+            LocalDate.MAX,
+            STICKER_FIXTURE,
+            TAG_FIXTURE,
+            "열심히, 잘, 최선을 다해 꼭 짱이 된다.",
+            emptyList(),
+        )
+
+        val savedGoal = goalRepository.save(goal)
+
+        // when
+        // then
+        assertThatCode {
+            goalService.getById(savedGoal.id!!)
+        }.doesNotThrowAnyException()
+    }
+
+    @Test
+    @DisplayName("User ID를 통해 유저가 가진 전체 Goal을 조회 할 수 있다.")
+    @Transactional
+    fun findAllByUserIdTest() {
+        // given
+        val goal1 = Goal(
+            USER_FIXTURE,
+            "제목1",
+            LocalDate.MAX,
+            STICKER_FIXTURE,
+            TAG_FIXTURE,
+            "",
+            emptyList(),
+        )
+
+        val goal2 = Goal(
+            USER_FIXTURE,
+            "제목2",
+            LocalDate.MAX,
+            STICKER_FIXTURE,
+            TAG_FIXTURE,
+            "",
+            emptyList(),
+        )
+
+        // when
+        // then
+        val savedGoals = goalService.findAllByUserId(USER_FIXTURE.id!!)
+
+        assertAll(
+            Executable {
+                assertThat(savedGoals.goals.goalInfos.size).isEqualTo(2)
+                assertThat(savedGoals.goals.goalInfos[0].title).isEqualTo(goal1.title)
+                assertThat(savedGoals.goals.goalInfos[1].title).isEqualTo(goal2.title)
+            },
+        )
+    }
+}

--- a/application/api/src/test/kotlin/io/raemian/api/integration/goal/GoalServiceTest.kt
+++ b/application/api/src/test/kotlin/io/raemian/api/integration/goal/GoalServiceTest.kt
@@ -114,6 +114,9 @@ class GoalServiceTest {
 
         // when
         // then
+        goalRepository.save(goal1)
+        goalRepository.save(goal2)
+
         val savedGoals = goalService.findAllByUserId(USER_FIXTURE.id!!)
 
         assertAll(

--- a/storage/db-core/src/main/kotlin/io/raemian/storage/db/core/goal/Goal.kt
+++ b/storage/db-core/src/main/kotlin/io/raemian/storage/db/core/goal/Goal.kt
@@ -41,9 +41,8 @@ class Goal(
     @JoinColumn(name = "tag_id", nullable = false)
     val tag: Tag,
 
-    @Column(nullable = false)
     @Nationalized
-    val description: String,
+    val description: String?,
 
     @OneToMany(mappedBy = "goal", cascade = [CascadeType.REMOVE], fetch = FetchType.LAZY)
     val tasks: List<Task>,

--- a/storage/db-core/src/main/kotlin/io/raemian/storage/db/core/goal/Goal.kt
+++ b/storage/db-core/src/main/kotlin/io/raemian/storage/db/core/goal/Goal.kt
@@ -39,7 +39,7 @@ class Goal(
 
     @ManyToOne
     @JoinColumn(name = "tag_id", nullable = false)
-    val tagId: Tag,
+    val tag: Tag,
 
     @Column(nullable = false)
     @Nationalized

--- a/storage/db-core/src/main/kotlin/io/raemian/storage/db/core/goal/Goal.kt
+++ b/storage/db-core/src/main/kotlin/io/raemian/storage/db/core/goal/Goal.kt
@@ -42,7 +42,7 @@ class Goal(
     val tag: Tag,
 
     @Nationalized
-    val description: String?,
+    val description: String = "",
 
     @OneToMany(mappedBy = "goal", cascade = [CascadeType.REMOVE], fetch = FetchType.LAZY)
     val tasks: List<Task>,

--- a/storage/db-core/src/main/kotlin/io/raemian/storage/db/core/goal/GoalRepository.kt
+++ b/storage/db-core/src/main/kotlin/io/raemian/storage/db/core/goal/GoalRepository.kt
@@ -6,6 +6,5 @@ interface GoalRepository : JpaRepository<Goal, Long> {
     fun findAllByUserId(userId: Long): List<Goal>
 
     override fun getById(id: Long): Goal =
-        findById(id)
-            .orElseThrow() { NoSuchElementException("목표가 없습니다 $id") }
+        findById(id).orElseThrow() { NoSuchElementException("목표가 없습니다 $id") }
 }

--- a/storage/db-core/src/main/kotlin/io/raemian/storage/db/core/goal/GoalRepository.kt
+++ b/storage/db-core/src/main/kotlin/io/raemian/storage/db/core/goal/GoalRepository.kt
@@ -1,0 +1,11 @@
+package io.raemian.storage.db.core.goal
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface GoalRepository : JpaRepository<Goal, Long> {
+    fun findAllByUserId(userId: Long): List<Goal>
+
+    override fun getById(id: Long): Goal =
+        findById(id)
+            .orElseThrow() { NoSuchElementException("목표가 없습니다 $id") }
+}

--- a/storage/db-core/src/main/kotlin/io/raemian/storage/db/core/sticker/StickerRepository.kt
+++ b/storage/db-core/src/main/kotlin/io/raemian/storage/db/core/sticker/StickerRepository.kt
@@ -2,4 +2,8 @@ package io.raemian.storage.db.core.sticker
 
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface StickerRepository : JpaRepository<Sticker, Long>
+interface StickerRepository : JpaRepository<Sticker, Long> {
+
+    override fun getById(id: Long): Sticker =
+        findById(id).orElseThrow { NoSuchElementException("존재하지 않는 스티커입니다. $id") }
+}

--- a/storage/db-core/src/main/kotlin/io/raemian/storage/db/core/tag/TagRepository.kt
+++ b/storage/db-core/src/main/kotlin/io/raemian/storage/db/core/tag/TagRepository.kt
@@ -2,4 +2,8 @@ package io.raemian.storage.db.core.tag
 
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface TagRepository : JpaRepository<Tag, Long>
+interface TagRepository : JpaRepository<Tag, Long> {
+
+    override fun getById(id: Long): Tag =
+        findById(id).orElseThrow { NoSuchElementException("존재하지 않는 태그입니다. $id") }
+}

--- a/storage/db-core/src/main/kotlin/io/raemian/storage/db/core/user/UserRepository.kt
+++ b/storage/db-core/src/main/kotlin/io/raemian/storage/db/core/user/UserRepository.kt
@@ -4,5 +4,9 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface UserRepository : JpaRepository<User, Long> {
     fun findByEmail(email: String): User?
+
     fun existsByEmail(email: String): Boolean
+
+    override fun getById(id: Long): User =
+        findById(id).orElseThrow { NoSuchElementException("존재하지 않는 유저입니다. $id") }
 }


### PR DESCRIPTION
명세에 맞춰 Goal 관련 비즈니스 로직을 작성하고 API를 구현하겠습니다. -> 명세 #27 

## 1. 구현 사항
- Goal의 단건 조회, 유저 Goal 전체 조회, 생성, 삭제 메서드와 API 구현
- year와 month를 표현하는 String을 통해 LocalDate를 생성하는 RaemianLocalDate를 생성했습니다. <br> String을 날짜 포멧에 맞는 숫자들로 변경하고, 고정된 Day 값을 관리할 객체가 필요할 것 같아 구현했습니다.
- Goal Create를 위한 User, Sticker, Tag의 getById 메서드를 구현했습니다.
- 모든 getById는 override했습니다. getById라는 이름을 사용하고 싶어 확장함수를 구현했었다가, Data JPA에서 deprecated된 해당 메서드에 의해 확장 함수가 가려져 orverride 하였습니다.
- Goal Create의 Description에 Nullable 속성이 추가되었습니다. 저번 회의에서 목표 설명은 비어있을 수도 있다고 언급했던 내용이 떠올라 클라이언트에서 빈 문자열을 보내줄 수도 있어 Nullable로 만들었습니다. <br> 물론 DB에 직접 null을 저장하는 것은 좋지 않다고 생각되어, null의 경우 빈 문자열 `""`로 값이 설정되도록 했습니다.
- 테스트는 아직 조회 테스트만 작성 되어 있습니다. 명세가 급하게 필요하다 하여 일단 전체 API를 완성한 다음 테스트를 마저 작성하겠습니다.


