### PR TITLE
[Refactor] 불필요하게 Wrapping된 Response들 Unwrapping

### DIFF
--- a/application/api/src/main/kotlin/io/raemian/api/goal/GoalService.kt
+++ b/application/api/src/main/kotlin/io/raemian/api/goal/GoalService.kt
@@ -24,7 +24,7 @@ class GoalService(
     @Transactional(readOnly = true)
     fun findAllByUserId(userId: Long): GoalsResponse {
         val goals = goalRepository.findAllByUserId(userId)
-        return GoalsResponse(goals)
+        return GoalsResponse.of(goals)
     }
 
     @Transactional(readOnly = true)

--- a/application/api/src/main/kotlin/io/raemian/api/goal/GoalService.kt
+++ b/application/api/src/main/kotlin/io/raemian/api/goal/GoalService.kt
@@ -24,7 +24,7 @@ class GoalService(
     @Transactional(readOnly = true)
     fun findAllByUserId(userId: Long): GoalsResponse {
         val goals = goalRepository.findAllByUserId(userId)
-        return GoalsResponse.of(goals)
+        return GoalsResponse.from(goals)
     }
 
     @Transactional(readOnly = true)

--- a/application/api/src/main/kotlin/io/raemian/api/goal/controller/response/GoalsResponse.kt
+++ b/application/api/src/main/kotlin/io/raemian/api/goal/controller/response/GoalsResponse.kt
@@ -4,15 +4,14 @@ import io.raemian.storage.db.core.goal.Goal
 import io.raemian.storage.db.core.sticker.StickerImage
 import java.time.LocalDate
 
-data class GoalsResponse(
+class GoalsResponse private constructor(
     val goals: Goals,
 ) {
 
-    constructor(goals: List<Goal>) : this(
-        Goals(
-            goals.map(::GoalInfo),
-        ),
-    )
+    companion object {
+        fun of(goals: List<Goal>): GoalsResponse =
+            GoalsResponse(Goals(goals.map(::GoalInfo)))
+    }
 
     data class GoalInfo(
         val id: Long?,

--- a/application/api/src/main/kotlin/io/raemian/api/goal/controller/response/GoalsResponse.kt
+++ b/application/api/src/main/kotlin/io/raemian/api/goal/controller/response/GoalsResponse.kt
@@ -9,7 +9,7 @@ class GoalsResponse private constructor(
 ) {
 
     companion object {
-        fun of(goals: List<Goal>): GoalsResponse =
+        fun from(goals: List<Goal>): GoalsResponse =
             GoalsResponse(goals.map(::GoalInfo))
     }
 

--- a/application/api/src/main/kotlin/io/raemian/api/goal/controller/response/GoalsResponse.kt
+++ b/application/api/src/main/kotlin/io/raemian/api/goal/controller/response/GoalsResponse.kt
@@ -5,12 +5,12 @@ import io.raemian.storage.db.core.sticker.StickerImage
 import java.time.LocalDate
 
 class GoalsResponse private constructor(
-    val goals: Goals,
+    val goals: List<GoalInfo>,
 ) {
 
     companion object {
         fun of(goals: List<Goal>): GoalsResponse =
-            GoalsResponse(Goals(goals.map(::GoalInfo)))
+            GoalsResponse(goals.map(::GoalInfo))
     }
 
     data class GoalInfo(
@@ -31,8 +31,4 @@ class GoalsResponse private constructor(
             description = goal.description,
         )
     }
-
-    data class Goals(
-        val goalInfos: List<GoalInfo>,
-    )
 }

--- a/application/api/src/test/kotlin/io/raemian/api/integration/goal/GoalServiceTest.kt
+++ b/application/api/src/test/kotlin/io/raemian/api/integration/goal/GoalServiceTest.kt
@@ -113,9 +113,9 @@ class GoalServiceTest {
 
         assertAll(
             Executable {
-                assertThat(savedGoals.goals.goalInfos.size).isEqualTo(2)
-                assertThat(savedGoals.goals.goalInfos[0].title).isEqualTo(goal1.title)
-                assertThat(savedGoals.goals.goalInfos[1].title).isEqualTo(goal2.title)
+                assertThat(savedGoals.goals.size).isEqualTo(2)
+                assertThat(savedGoals.goals[0].title).isEqualTo(goal1.title)
+                assertThat(savedGoals.goals[1].title).isEqualTo(goal2.title)
             },
         )
     }

--- a/storage/db-core/src/main/kotlin/io/raemian/storage/db/core/sticker/StickerImage.kt
+++ b/storage/db-core/src/main/kotlin/io/raemian/storage/db/core/sticker/StickerImage.kt
@@ -1,8 +1,10 @@
 package io.raemian.storage.db.core.sticker
 
+import com.fasterxml.jackson.annotation.JsonValue
 import jakarta.persistence.Embeddable
 
 @Embeddable
 data class StickerImage(
+    @JsonValue
     val stickerImage: String,
 )


### PR DESCRIPTION
이슈 "#41"에 언급한 것과 같이 API를 사용하는 클라이언트 분들이 편하게 사용할 수 있도록 개선하는 것이 목표였습니다.

## 기존
![image](https://github.com/depromeet/amazing3-be/assets/71186266/16ee4f37-26a3-446a-bdb4-90d810ffc1b2)


<br>

## 변경 이후
![image](https://github.com/depromeet/amazing3-be/assets/71186266/3ae29c22-c4ed-4964-80ea-8c3f67f76e50)

## Unwraaping 방식이 다른 이유
StickerImage는 간단하게 @JsonValue를 추가함으로써 구현했습니다.
GoalsResponse에도 똑같이 적용할 수 있었지만, 정적 팩터리 메서드를 통해 해결했습니다. 그렇게 한 이유는 불필요한 일급 컬렉션 Goals를 제거하기 위해서입니다.

<br>

그리고 정적 팩터리 메서드를 통해서만 생성할 수 있도록, 기본 생성자를 private로 막았습니다.