### PR TITLE
[Refactor] Goal 전체 조회 API 수정 - 총 목표 갯수 추가, title, description 삭제, deadline 포맷 변경

### DIFF
--- a/application/api/src/main/kotlin/io/raemian/api/goal/controller/response/GoalResponse.kt
+++ b/application/api/src/main/kotlin/io/raemian/api/goal/controller/response/GoalResponse.kt
@@ -1,5 +1,6 @@
 package io.raemian.api.goal.controller.response
 
+import io.raemian.api.support.format
 import io.raemian.storage.db.core.goal.Goal
 import io.raemian.storage.db.core.sticker.StickerImage
 import io.raemian.storage.db.core.tag.Tag

--- a/application/api/src/main/kotlin/io/raemian/api/goal/controller/response/GoalResponse.kt
+++ b/application/api/src/main/kotlin/io/raemian/api/goal/controller/response/GoalResponse.kt
@@ -4,11 +4,10 @@ import io.raemian.storage.db.core.goal.Goal
 import io.raemian.storage.db.core.sticker.StickerImage
 import io.raemian.storage.db.core.tag.Tag
 import io.raemian.storage.db.core.task.Task
-import java.time.LocalDate
 
 data class GoalResponse(
     val title: String,
-    val deadline: LocalDate,
+    val deadline: String,
     val sticker: StickerImage,
     val tagInfo: TagInfo,
     val tasks: List<TaskInfo>,
@@ -16,7 +15,7 @@ data class GoalResponse(
 
     constructor(goal: Goal) : this(
         goal.title,
-        goal.deadline,
+        goal.deadline.format(),
         goal.sticker.stickerImage,
         TagInfo(goal.tag),
         goal.tasks.map(::TaskInfo),

--- a/application/api/src/main/kotlin/io/raemian/api/goal/controller/response/GoalsResponse.kt
+++ b/application/api/src/main/kotlin/io/raemian/api/goal/controller/response/GoalsResponse.kt
@@ -1,17 +1,8 @@
 package io.raemian.api.goal.controller.response
 
+import io.raemian.api.support.format
 import io.raemian.storage.db.core.goal.Goal
 import io.raemian.storage.db.core.sticker.StickerImage
-import java.time.LocalDate
-
-fun LocalDate.format(): String {
-    var month = this.monthValue.toString()
-    if (month.length == 1) {
-        month = "0$month"
-    }
-    
-    return "${this.year}.$month"
-}
 
 data class GoalsResponse(
     val goals: Goals,

--- a/application/api/src/main/kotlin/io/raemian/api/goal/controller/response/GoalsResponse.kt
+++ b/application/api/src/main/kotlin/io/raemian/api/goal/controller/response/GoalsResponse.kt
@@ -16,20 +16,16 @@ data class GoalsResponse(
 
     data class GoalInfo(
         val id: Long?,
-        val title: String,
         val deadline: LocalDate,
         val sticker: StickerImage,
         val tagContent: String,
-        val description: String? = "",
     ) {
 
         constructor(goal: Goal) : this(
             id = goal.id,
-            title = goal.title,
             deadline = goal.deadline,
             sticker = goal.sticker.stickerImage,
             tagContent = goal.tag.content,
-            description = goal.description,
         )
     }
 

--- a/application/api/src/main/kotlin/io/raemian/api/goal/controller/response/GoalsResponse.kt
+++ b/application/api/src/main/kotlin/io/raemian/api/goal/controller/response/GoalsResponse.kt
@@ -6,12 +6,14 @@ import io.raemian.storage.db.core.sticker.StickerImage
 
 data class GoalsResponse(
     val goals: Goals,
+    val goalsCount: Int,
 ) {
 
     constructor(goals: List<Goal>) : this(
         Goals(
             goals.map(::GoalInfo),
         ),
+        goals.size,
     )
 
     data class GoalInfo(

--- a/application/api/src/main/kotlin/io/raemian/api/goal/controller/response/GoalsResponse.kt
+++ b/application/api/src/main/kotlin/io/raemian/api/goal/controller/response/GoalsResponse.kt
@@ -4,6 +4,15 @@ import io.raemian.storage.db.core.goal.Goal
 import io.raemian.storage.db.core.sticker.StickerImage
 import java.time.LocalDate
 
+fun LocalDate.format(): String {
+    var month = this.monthValue.toString()
+    if (month.length == 1) {
+        month = "0$month"
+    }
+    
+    return "${this.year}.$month"
+}
+
 data class GoalsResponse(
     val goals: Goals,
 ) {
@@ -16,14 +25,14 @@ data class GoalsResponse(
 
     data class GoalInfo(
         val id: Long?,
-        val deadline: LocalDate,
+        val deadline: String,
         val sticker: StickerImage,
         val tagContent: String,
     ) {
 
         constructor(goal: Goal) : this(
             id = goal.id,
-            deadline = goal.deadline,
+            deadline = goal.deadline.format(),
             sticker = goal.sticker.stickerImage,
             tagContent = goal.tag.content,
         )

--- a/application/api/src/main/kotlin/io/raemian/api/support/RaemianLocalDate.kt
+++ b/application/api/src/main/kotlin/io/raemian/api/support/RaemianLocalDate.kt
@@ -5,7 +5,7 @@ import java.time.Month
 import java.time.Year
 
 fun LocalDate.format(): String {
-    var month = (this.monthValue + 1).toString()
+    var month = (this.monthValue).toString()
     if (month.length == 1) {
         month = "0${month}"
     }

--- a/application/api/src/main/kotlin/io/raemian/api/support/RaemianLocalDate.kt
+++ b/application/api/src/main/kotlin/io/raemian/api/support/RaemianLocalDate.kt
@@ -4,6 +4,15 @@ import java.time.LocalDate
 import java.time.Month
 import java.time.Year
 
+fun LocalDate.format(): String {
+    var month = this.monthValue.toString()
+    if (month.length == 1) {
+        month = "0$month"
+    }
+
+    return "${this.year}.$month"
+}
+
 object RaemianLocalDate {
 
     private const val DAY_OF_MONTH = 1

--- a/application/api/src/main/kotlin/io/raemian/api/support/RaemianLocalDate.kt
+++ b/application/api/src/main/kotlin/io/raemian/api/support/RaemianLocalDate.kt
@@ -7,10 +7,10 @@ import java.time.Year
 fun LocalDate.format(): String {
     var month = (this.monthValue).toString()
     if (month.length == 1) {
-        month = "0${month}"
+        month = "0$month"
     }
 
-    return "${this.year}.${month}"
+    return "${this.year}.$month"
 }
 
 object RaemianLocalDate {

--- a/application/api/src/main/kotlin/io/raemian/api/support/RaemianLocalDate.kt
+++ b/application/api/src/main/kotlin/io/raemian/api/support/RaemianLocalDate.kt
@@ -5,12 +5,12 @@ import java.time.Month
 import java.time.Year
 
 fun LocalDate.format(): String {
-    var month = this.monthValue.toString()
+    var month = (this.monthValue + 1).toString()
     if (month.length == 1) {
-        month = "0$month"
+        month = "0${month}"
     }
 
-    return "${this.year}.$month"
+    return "${this.year}.${month}"
 }
 
 object RaemianLocalDate {

--- a/application/api/src/test/kotlin/io/raemian/api/integration/goal/GoalServiceTest.kt
+++ b/application/api/src/test/kotlin/io/raemian/api/integration/goal/GoalServiceTest.kt
@@ -104,18 +104,67 @@ class GoalServiceTest {
             emptyList(),
         )
 
-        // when
-        // then
         goalRepository.save(goal1)
         goalRepository.save(goal2)
 
+        // when
         val savedGoals = goalService.findAllByUserId(USER_FIXTURE.id!!)
 
+        // then
         assertAll(
             Executable {
                 assertThat(savedGoals.goals.goalInfos.size).isEqualTo(2)
                 assertThat(savedGoals.goals.goalInfos[0].tagContent).isEqualTo(goal1.tag.content)
                 assertThat(savedGoals.goals.goalInfos[1].tagContent).isEqualTo(goal2.tag.content)
+            },
+        )
+    }
+
+    @Test
+    @DisplayName("GoalsResponse와 GoalResponse의 deadline 포멧은 'YYYY.MM'이다.")
+    @Transactional
+    fun responseFormattingTest() {
+        // given
+        val now = LocalDate.now()
+        val goal1 = Goal(
+            USER_FIXTURE,
+            "제목1",
+            now,
+            STICKER_FIXTURE,
+            TAG_FIXTURE,
+            "",
+            emptyList(),
+        )
+
+        val goal2 = Goal(
+            USER_FIXTURE,
+            "제목2",
+            now,
+            STICKER_FIXTURE,
+            TAG_FIXTURE,
+            "",
+            emptyList(),
+        )
+
+        goalRepository.save(goal1)
+        goalRepository.save(goal2)
+
+        // when
+        val savedGoal = goalService.getById(goal1.id!!)
+        val savedGoals = goalService.findAllByUserId(USER_FIXTURE.id!!)
+
+        // then
+        var month = (now.monthValue + 1).toString()
+        if (month.length == 1) {
+            month = "0$month"
+        }
+        val deadline = "${now.year}.${month}"
+
+        assertAll(
+            Executable {
+                assertThat(savedGoal.deadline).isEqualTo(deadline)
+                assertThat(savedGoals.goals.goalInfos[0].deadline).isEqualTo(deadline)
+                assertThat(savedGoals.goals.goalInfos[1].deadline).isEqualTo(deadline)
             },
         )
     }

--- a/application/api/src/test/kotlin/io/raemian/api/integration/goal/GoalServiceTest.kt
+++ b/application/api/src/test/kotlin/io/raemian/api/integration/goal/GoalServiceTest.kt
@@ -158,7 +158,7 @@ class GoalServiceTest {
         if (month.length == 1) {
             month = "0$month"
         }
-        val deadline = "${now.year}.${month}"
+        val deadline = "${now.year}.$month"
 
         assertAll(
             Executable {

--- a/application/api/src/test/kotlin/io/raemian/api/integration/goal/GoalServiceTest.kt
+++ b/application/api/src/test/kotlin/io/raemian/api/integration/goal/GoalServiceTest.kt
@@ -113,7 +113,7 @@ class GoalServiceTest {
         // then
         assertAll(
             Executable {
-                assertThat(savedGoals.goals.goalInfos.size).isEqualTo(2)
+                assertThat(savedGoals.goalsCount).isEqualTo(2)
                 assertThat(savedGoals.goals.goalInfos[0].tagContent).isEqualTo(goal1.tag.content)
                 assertThat(savedGoals.goals.goalInfos[1].tagContent).isEqualTo(goal2.tag.content)
             },
@@ -154,7 +154,7 @@ class GoalServiceTest {
         val savedGoals = goalService.findAllByUserId(USER_FIXTURE.id!!)
 
         // then
-        var month = (now.monthValue + 1).toString()
+        var month = (now.monthValue).toString()
         if (month.length == 1) {
             month = "0$month"
         }

--- a/application/api/src/test/kotlin/io/raemian/api/integration/goal/GoalServiceTest.kt
+++ b/application/api/src/test/kotlin/io/raemian/api/integration/goal/GoalServiceTest.kt
@@ -114,8 +114,8 @@ class GoalServiceTest {
         assertAll(
             Executable {
                 assertThat(savedGoals.goals.goalInfos.size).isEqualTo(2)
-                assertThat(savedGoals.goals.goalInfos[0].title).isEqualTo(goal1.title)
-                assertThat(savedGoals.goals.goalInfos[1].title).isEqualTo(goal2.title)
+                assertThat(savedGoals.goals.goalInfos[0].tagContent).isEqualTo(goal1.tag.content)
+                assertThat(savedGoals.goals.goalInfos[1].tagContent).isEqualTo(goal2.tag.content)
             },
         )
     }


### PR DESCRIPTION
## 변경 내용

1. deadline의 포멧을 "YYYY.MM"과 같은 형태로 사용할 수 있도록 LocalDate 확장함수 format()을 추가했습니다.
![image](https://github.com/depromeet/amazing3-be/assets/71186266/a6fa050b-6946-42f6-a83f-2de2e27c44be)

<br> 

2. GoalResponse, GoalsResponse에서 title, description을 제거했습니다.
3. GoalsResponse에 유저가 가진 목표 전체 갯수인 goalsCount를 추가했습니다. 