### PR TITLE
[Refactor] 생성 API에 생성 리소스 반환 추가 (#40)

### DIFF
--- a/application/api/src/main/kotlin/io/raemian/api/goal/CreateGoalResponse.kt
+++ b/application/api/src/main/kotlin/io/raemian/api/goal/CreateGoalResponse.kt
@@ -1,5 +1,0 @@
-package io.raemian.api.goal
-
-data class CreateGoalResponse(
-    val id: Long,
-)

--- a/application/api/src/main/kotlin/io/raemian/api/goal/GoalService.kt
+++ b/application/api/src/main/kotlin/io/raemian/api/goal/GoalService.kt
@@ -2,6 +2,7 @@ package io.raemian.api.goal
 
 import io.raemian.api.goal.controller.request.CreateGoalRequest
 import io.raemian.api.goal.controller.request.DeleteGoalRequest
+import io.raemian.api.goal.controller.response.CreateGoalResponse
 import io.raemian.api.goal.controller.response.GoalResponse
 import io.raemian.api.goal.controller.response.GoalsResponse
 import io.raemian.api.sticker.StickerService
@@ -44,7 +45,7 @@ class GoalService(
 
         val goal = Goal(user, title, deadline, sticker, tag, description!!, emptyList())
         goalRepository.save(goal)
-        return CreateGoalResponse(goal.id!!)
+        return CreateGoalResponse(goal)
     }
 
     @Transactional

--- a/application/api/src/main/kotlin/io/raemian/api/goal/controller/GoalController.kt
+++ b/application/api/src/main/kotlin/io/raemian/api/goal/controller/GoalController.kt
@@ -1,10 +1,10 @@
 package io.raemian.api.goal.controller
 
 import io.raemian.api.auth.domain.CurrentUser
-import io.raemian.api.goal.CreateGoalResponse
 import io.raemian.api.goal.GoalService
 import io.raemian.api.goal.controller.request.CreateGoalRequest
 import io.raemian.api.goal.controller.request.DeleteGoalRequest
+import io.raemian.api.goal.controller.response.CreateGoalResponse
 import io.raemian.api.goal.controller.response.GoalResponse
 import io.raemian.api.goal.controller.response.GoalsResponse
 import io.swagger.v3.oas.annotations.Operation

--- a/application/api/src/main/kotlin/io/raemian/api/goal/controller/response/CreateGoalResponse.kt
+++ b/application/api/src/main/kotlin/io/raemian/api/goal/controller/response/CreateGoalResponse.kt
@@ -1,0 +1,24 @@
+package io.raemian.api.goal.controller.response
+
+import io.raemian.api.support.format
+import io.raemian.storage.db.core.goal.Goal
+import io.raemian.storage.db.core.sticker.StickerImage
+
+data class CreateGoalResponse(
+    val id: Long,
+    val title: String,
+    val description: String,
+    val deadline: String,
+    val sticker: StickerImage,
+    val tag: String,
+) {
+
+    constructor(goal: Goal) : this(
+        id = goal.id!!,
+        title = goal.title,
+        description = goal.description,
+        deadline = goal.deadline.format(),
+        sticker = goal.sticker.stickerImage,
+        tag = goal.tag.content,
+    )
+}

--- a/application/api/src/main/kotlin/io/raemian/api/task/TaskService.kt
+++ b/application/api/src/main/kotlin/io/raemian/api/task/TaskService.kt
@@ -24,7 +24,7 @@ class TaskService(
 
         val task = Task.createTask(goal, createTaskRequest.description)
         taskRepository.save(task)
-        return CreateTaskResponse(task.id!!)
+        return CreateTaskResponse(task.id!!, task.description)
     }
 
     @Transactional

--- a/application/api/src/main/kotlin/io/raemian/api/task/controller/TaskController.kt
+++ b/application/api/src/main/kotlin/io/raemian/api/task/controller/TaskController.kt
@@ -7,6 +7,7 @@ import io.raemian.api.task.controller.request.CreateTaskRequest
 import io.raemian.api.task.controller.request.RewriteTaskRequest
 import io.raemian.api.task.controller.request.UpdateTaskCompletionRequest
 import io.raemian.api.task.controller.response.CreateTaskResponse
+import io.swagger.v3.oas.annotations.Operation
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -23,6 +24,7 @@ class TaskController(
     private val taskService: TaskService,
 ) {
 
+    @Operation(summary = "Task 생성 API입니다.")
     @PostMapping
     fun create(
         @AuthenticationPrincipal currentUser: CurrentUser,
@@ -33,6 +35,7 @@ class TaskController(
             .body(response)
     }
 
+    @Operation(summary = "Task의 description을 수정하는 API입니다.")
     @PatchMapping("/{taskId}/description")
     fun rewrite(
         @AuthenticationPrincipal currentUser: CurrentUser,
@@ -43,6 +46,7 @@ class TaskController(
         return ResponseEntity.ok().build()
     }
 
+    @Operation(summary = "Task의 완료 여부를 수정하는 API입니다.")
     @PatchMapping("/{taskId}/isDone")
     fun updateTaskCompletion(
         @AuthenticationPrincipal currentUser: CurrentUser,
@@ -53,6 +57,7 @@ class TaskController(
         return ResponseEntity.ok().build()
     }
 
+    @Operation(summary = "Task를 삭제하는 API입니다.")
     @DeleteMapping("/{taskId}")
     fun updateTaskCompletion(
         @AuthenticationPrincipal currentUser: CurrentUser,

--- a/application/api/src/main/kotlin/io/raemian/api/task/controller/response/CreateTaskResponse.kt
+++ b/application/api/src/main/kotlin/io/raemian/api/task/controller/response/CreateTaskResponse.kt
@@ -2,4 +2,5 @@ package io.raemian.api.task.controller.response
 
 class CreateTaskResponse(
     val id: Long,
+    val description: String,
 )


### PR DESCRIPTION
![image](https://github.com/depromeet/amazing3-be/assets/71186266/a97a6ce6-9649-4673-9b7a-d80d735ed50a)


Goal과 Task 생성 API에선 현재 created 응답과 리소스 접근 Endpoint 만을 전달하고 있습니다.
습관적으로 커맨드와 쿼리를 분리해서 작성했다. 클라이언트 입장에선 쿼리를 2번 날려야 하는 번거로움이 있었습니다.
생성된 리소스를 반환하겠습니다.

## 추가된 내용
1. 기존 Goal Create API엔 id만이 있었습니다. (201 응답을 위한 Endpoint 제공시 첨부되던 id 값) <br> Goal 생성 이후 페이지에서 화면을 보여주기 위한 값들을 추가해줬습니다.

```kotlin
data class CreateGoalResponse(
    val id: Long,
    val title: String,
    val description: String,
    val deadline: String,
    val sticker: StickerImage,
    val tag: String,
) {

    constructor(goal: Goal) : this(
        id = goal.id!!,
        title = goal.title,
        description = goal.description,
        deadline = goal.deadline.format(),
        sticker = goal.sticker.stickerImage,
        tag = goal.tag.content,
    )
}

```

<br>

2. Task Create API엔 description이 추가 되었습니다.
```kotlin
class CreateTaskResponse(
    val id: Long,
    val description: String,
)
```



## 참고
이 PR은 이전 PR이 merge된 이후 sync를 맞춰야 빌드 테스트에 성공할 것으로 생각됩니다. 나머지 작업이 빨리 끝나 미리 올렸습니다. 이전 PR Merge이후 싱크 맞추겠습니다.