### PR TITLE
[Feature] 기준에 따라 Goal 조회 결과 정렬 (#38)

### DIFF
--- a/application/api/src/main/kotlin/io/raemian/api/goal/GoalReadService.kt
+++ b/application/api/src/main/kotlin/io/raemian/api/goal/GoalReadService.kt
@@ -1,0 +1,33 @@
+package io.raemian.api.goal
+
+import io.raemian.api.goal.controller.response.GoalResponse
+import io.raemian.api.goal.controller.response.GoalsResponse
+import io.raemian.storage.db.core.goal.Goal
+import io.raemian.storage.db.core.goal.GoalRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class GoalReadService(
+    private val goalRepository: GoalRepository,
+) {
+    @Transactional(readOnly = true)
+    fun findAllByUserId(userId: Long): GoalsResponse {
+        val goals = goalRepository.findAllByUserId(userId)
+        val sortedGoals = sortByDeadlineAscendingAndCreatedAtDescending(goals)
+        return GoalsResponse.from(sortedGoals)
+    }
+
+    @Transactional(readOnly = true)
+    fun getById(id: Long): GoalResponse {
+        val goal = goalRepository.getById(id)
+        return GoalResponse(goal)
+    }
+
+    private fun sortByDeadlineAscendingAndCreatedAtDescending(goals: List<Goal>): List<Goal> {
+        return goals.sortedWith(
+            compareBy<Goal> { it.deadline }
+                .thenByDescending { it.createdAt },
+        )
+    }
+}

--- a/application/api/src/main/kotlin/io/raemian/api/goal/GoalService.kt
+++ b/application/api/src/main/kotlin/io/raemian/api/goal/GoalService.kt
@@ -25,7 +25,8 @@ class GoalService(
     @Transactional(readOnly = true)
     fun findAllByUserId(userId: Long): GoalsResponse {
         val goals = goalRepository.findAllByUserId(userId)
-        return GoalsResponse.from(goals)
+        val sortedGoals = sortByDeadlineAscendingAndCreatedAtDescending(goals)
+        return GoalsResponse.from(sortedGoals)
     }
 
     @Transactional(readOnly = true)
@@ -53,6 +54,13 @@ class GoalService(
         val goal = goalRepository.getById(deleteGoalRequest.goalId)
         validateGoalIsUsers(userId, goal)
         goalRepository.delete(goal)
+    }
+
+    private fun sortByDeadlineAscendingAndCreatedAtDescending(goals: List<Goal>): List<Goal> {
+        return goals.sortedWith(
+            compareBy<Goal> { it.deadline }
+                .thenByDescending { it.createdAt },
+        )
     }
 
     private fun validateGoalIsUsers(userId: Long, goal: Goal) {

--- a/application/api/src/main/kotlin/io/raemian/api/goal/GoalService.kt
+++ b/application/api/src/main/kotlin/io/raemian/api/goal/GoalService.kt
@@ -3,8 +3,6 @@ package io.raemian.api.goal
 import io.raemian.api.goal.controller.request.CreateGoalRequest
 import io.raemian.api.goal.controller.request.DeleteGoalRequest
 import io.raemian.api.goal.controller.response.CreateGoalResponse
-import io.raemian.api.goal.controller.response.GoalResponse
-import io.raemian.api.goal.controller.response.GoalsResponse
 import io.raemian.api.sticker.StickerService
 import io.raemian.api.support.RaemianLocalDate
 import io.raemian.api.tag.TagService
@@ -21,20 +19,6 @@ class GoalService(
     private val tagService: TagService,
     private val goalRepository: GoalRepository,
 ) {
-
-    @Transactional(readOnly = true)
-    fun findAllByUserId(userId: Long): GoalsResponse {
-        val goals = goalRepository.findAllByUserId(userId)
-        val sortedGoals = sortByDeadlineAscendingAndCreatedAtDescending(goals)
-        return GoalsResponse.from(sortedGoals)
-    }
-
-    @Transactional(readOnly = true)
-    fun getById(id: Long): GoalResponse {
-        val goal = goalRepository.getById(id)
-        return GoalResponse(goal)
-    }
-
     @Transactional
     fun create(userId: Long, createGoalRequest: CreateGoalRequest): CreateGoalResponse {
         val (title, yearOfDeadline, monthOfDeadLine, stickerId, tagId, description) = createGoalRequest
@@ -54,13 +38,6 @@ class GoalService(
         val goal = goalRepository.getById(deleteGoalRequest.goalId)
         validateGoalIsUsers(userId, goal)
         goalRepository.delete(goal)
-    }
-
-    private fun sortByDeadlineAscendingAndCreatedAtDescending(goals: List<Goal>): List<Goal> {
-        return goals.sortedWith(
-            compareBy<Goal> { it.deadline }
-                .thenByDescending { it.createdAt },
-        )
     }
 
     private fun validateGoalIsUsers(userId: Long, goal: Goal) {

--- a/application/api/src/main/kotlin/io/raemian/api/goal/controller/GoalController.kt
+++ b/application/api/src/main/kotlin/io/raemian/api/goal/controller/GoalController.kt
@@ -1,6 +1,7 @@
 package io.raemian.api.goal.controller
 
 import io.raemian.api.auth.domain.CurrentUser
+import io.raemian.api.goal.GoalReadService
 import io.raemian.api.goal.GoalService
 import io.raemian.api.goal.controller.request.CreateGoalRequest
 import io.raemian.api.goal.controller.request.DeleteGoalRequest
@@ -25,6 +26,7 @@ fun String.toUri(): URI = URI.create(this)
 @RequestMapping("/goal")
 class GoalController(
     private val goalService: GoalService,
+    private val goalReadService: GoalReadService,
 ) {
 
     @Operation(summary = "유저 목표 전체 조회 API")
@@ -32,7 +34,7 @@ class GoalController(
     fun findAllByUserId(
         @AuthenticationPrincipal currentUser: CurrentUser,
     ): ResponseEntity<GoalsResponse> {
-        val response = goalService.findAllByUserId(currentUser.id)
+        val response = goalReadService.findAllByUserId(currentUser.id)
         return ResponseEntity.ok(response)
     }
 
@@ -41,7 +43,7 @@ class GoalController(
     fun getByUserId(
         @PathVariable("goalId") goalId: Long,
     ): ResponseEntity<GoalResponse> =
-        ResponseEntity.ok(goalService.getById(goalId))
+        ResponseEntity.ok(goalReadService.getById(goalId))
 
     @Operation(summary = "목표 생성 API")
     @PostMapping

--- a/application/api/src/test/kotlin/io/raemian/api/integration/goal/GoalReadServiceTest.kt
+++ b/application/api/src/test/kotlin/io/raemian/api/integration/goal/GoalReadServiceTest.kt
@@ -1,6 +1,6 @@
 package io.raemian.api.integration.goal
 
-import io.raemian.api.goal.GoalService
+import io.raemian.api.goal.GoalReadService
 import io.raemian.storage.db.core.goal.Goal
 import io.raemian.storage.db.core.goal.GoalRepository
 import io.raemian.storage.db.core.sticker.Sticker
@@ -23,7 +23,7 @@ import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
 
 @SpringBootTest
-class GoalServiceTest {
+class GoalReadServiceTest {
 
     companion object {
         val USER_FIXTURE = User(
@@ -40,7 +40,7 @@ class GoalServiceTest {
     }
 
     @Autowired
-    private lateinit var goalService: GoalService
+    private lateinit var goalReadService: GoalReadService
 
     @Autowired
     private lateinit var goalRepository: GoalRepository
@@ -61,13 +61,13 @@ class GoalServiceTest {
     fun getByIdTest() {
         // given
         val goal = Goal(
-            USER_FIXTURE,
-            "짱이 될거야",
-            LocalDate.MAX,
-            STICKER_FIXTURE,
-            TAG_FIXTURE,
-            "열심히, 잘, 최선을 다해 꼭 짱이 된다.",
-            emptyList(),
+            user = USER_FIXTURE,
+            title = "짱이 될거야",
+            deadline = LocalDate.MAX,
+            sticker = STICKER_FIXTURE,
+            tag = TAG_FIXTURE,
+            description = "열심히, 잘, 최선을 다해 꼭 짱이 된다.",
+            tasks = emptyList(),
         )
 
         val savedGoal = goalRepository.save(goal)
@@ -75,7 +75,7 @@ class GoalServiceTest {
         // when
         // then
         assertThatCode {
-            goalService.getById(savedGoal.id!!)
+            goalReadService.getById(savedGoal.id!!)
         }.doesNotThrowAnyException()
     }
 
@@ -85,30 +85,30 @@ class GoalServiceTest {
     fun findAllByUserIdTest() {
         // given
         val goal1 = Goal(
-            USER_FIXTURE,
-            "제목1",
-            LocalDate.MAX,
-            STICKER_FIXTURE,
-            TAG_FIXTURE,
-            "",
-            emptyList(),
+            user = USER_FIXTURE,
+            title = "제목1",
+            deadline = LocalDate.MAX,
+            sticker = STICKER_FIXTURE,
+            tag = TAG_FIXTURE,
+            description = "",
+            tasks = emptyList(),
         )
 
         val goal2 = Goal(
-            USER_FIXTURE,
-            "제목2",
-            LocalDate.MAX,
-            STICKER_FIXTURE,
-            TAG_FIXTURE,
-            "",
-            emptyList(),
+            user = USER_FIXTURE,
+            title = "제목2",
+            deadline = LocalDate.MAX,
+            sticker = STICKER_FIXTURE,
+            tag = TAG_FIXTURE,
+            description = "",
+            tasks = emptyList(),
         )
 
         goalRepository.save(goal1)
         goalRepository.save(goal2)
 
         // when
-        val savedGoals = goalService.findAllByUserId(USER_FIXTURE.id!!)
+        val savedGoals = goalReadService.findAllByUserId(USER_FIXTURE.id!!)
 
         // then
         assertAll(
@@ -127,31 +127,30 @@ class GoalServiceTest {
         // given
         val now = LocalDate.now()
         val goal1 = Goal(
-            USER_FIXTURE,
-            "제목1",
-            now,
-            STICKER_FIXTURE,
-            TAG_FIXTURE,
-            "",
-            emptyList(),
+            user = USER_FIXTURE,
+            title = "제목1",
+            deadline = now,
+            sticker = STICKER_FIXTURE,
+            tag = TAG_FIXTURE,
+            description = "",
+            tasks = emptyList(),
         )
 
         val goal2 = Goal(
-            USER_FIXTURE,
-            "제목2",
-            now,
-            STICKER_FIXTURE,
-            TAG_FIXTURE,
-            "",
-            emptyList(),
+            user = USER_FIXTURE,
+            title = "제목2",
+            deadline = now,
+            sticker = STICKER_FIXTURE,
+            tag = TAG_FIXTURE,
+            description = "",
+            tasks = emptyList(),
         )
-
         goalRepository.save(goal1)
         goalRepository.save(goal2)
 
         // when
-        val savedGoal = goalService.getById(goal1.id!!)
-        val savedGoals = goalService.findAllByUserId(USER_FIXTURE.id!!)
+        val savedGoal = goalReadService.getById(goal1.id!!)
+        val savedGoals = goalReadService.findAllByUserId(USER_FIXTURE.id!!)
 
         // then
         var month = (now.monthValue).toString()
@@ -176,35 +175,35 @@ class GoalServiceTest {
     fun sortGoalsTest() {
         // given
         val deadline이_내일이고_가장_처음_만들어진_객체 = Goal(
-            USER_FIXTURE,
-            "제목1",
-            LocalDate.now()
+            user = USER_FIXTURE,
+            title = "제목1",
+            deadline = LocalDate.now()
                 .plusDays(1),
-            STICKER_FIXTURE,
-            TAG_FIXTURE,
-            "",
-            emptyList(),
+            sticker = STICKER_FIXTURE,
+            tag = TAG_FIXTURE,
+            description = "",
+            tasks = emptyList(),
         )
 
         val deadline이_내일이고_가장_나중에_만들어진_객체 = Goal(
-            USER_FIXTURE,
-            "제목2",
-            LocalDate.now()
+            user = USER_FIXTURE,
+            title = "제목2",
+            deadline = LocalDate.now()
                 .plusDays(1),
-            STICKER_FIXTURE,
-            TAG_FIXTURE,
-            "",
-            emptyList(),
+            sticker = STICKER_FIXTURE,
+            tag = TAG_FIXTURE,
+            description = "",
+            tasks = emptyList(),
         )
 
         val deadline이_오늘인_객체 = Goal(
-            USER_FIXTURE,
-            "제목2",
-            LocalDate.now(),
-            STICKER_FIXTURE,
-            TAG_FIXTURE,
-            "",
-            emptyList(),
+            user = USER_FIXTURE,
+            title = "제목2",
+            deadline = LocalDate.now(),
+            sticker = STICKER_FIXTURE,
+            tag = TAG_FIXTURE,
+            description = "",
+            tasks = emptyList(),
         )
 
         // 역순으로 저장한다.
@@ -213,7 +212,7 @@ class GoalServiceTest {
         goalRepository.save(deadline이_오늘인_객체)
 
         // when
-        val savedGoals = goalService.findAllByUserId(USER_FIXTURE.id!!)
+        val savedGoals = goalReadService.findAllByUserId(USER_FIXTURE.id!!)
 
         // then
         assertAll(

--- a/application/api/src/test/kotlin/io/raemian/api/integration/goal/GoalServiceTest.kt
+++ b/application/api/src/test/kotlin/io/raemian/api/integration/goal/GoalServiceTest.kt
@@ -168,4 +168,60 @@ class GoalServiceTest {
             },
         )
     }
+
+    // 정렬 테스트
+    @Test
+    @DisplayName("Goals 전체 조회시 Deadline 기준 오름차순, CreatedAt 기준 내림차순으로 정렬된다.")
+    @Transactional
+    fun sortGoalsTest() {
+        // given
+        val deadline이_내일이고_가장_처음_만들어진_객체 = Goal(
+            USER_FIXTURE,
+            "제목1",
+            LocalDate.now()
+                .plusDays(1),
+            STICKER_FIXTURE,
+            TAG_FIXTURE,
+            "",
+            emptyList(),
+        )
+
+        val deadline이_내일이고_가장_나중에_만들어진_객체 = Goal(
+            USER_FIXTURE,
+            "제목2",
+            LocalDate.now()
+                .plusDays(1),
+            STICKER_FIXTURE,
+            TAG_FIXTURE,
+            "",
+            emptyList(),
+        )
+
+        val deadline이_오늘인_객체 = Goal(
+            USER_FIXTURE,
+            "제목2",
+            LocalDate.now(),
+            STICKER_FIXTURE,
+            TAG_FIXTURE,
+            "",
+            emptyList(),
+        )
+
+        // 역순으로 저장한다.
+        goalRepository.save(deadline이_내일이고_가장_처음_만들어진_객체)
+        goalRepository.save(deadline이_내일이고_가장_나중에_만들어진_객체)
+        goalRepository.save(deadline이_오늘인_객체)
+
+        // when
+        val savedGoals = goalService.findAllByUserId(USER_FIXTURE.id!!)
+
+        // then
+        assertAll(
+            Executable {
+                assertThat(savedGoals.goals[0].id).isEqualTo(deadline이_오늘인_객체.id)
+                assertThat(savedGoals.goals[1].id).isEqualTo(deadline이_내일이고_가장_나중에_만들어진_객체.id)
+                assertThat(savedGoals.goals[2].id).isEqualTo(deadline이_내일이고_가장_처음_만들어진_객체.id)
+            },
+        )
+    }
 }


### PR DESCRIPTION
명세에 맞게 Goal을 정렬합니다.

![image](https://github.com/depromeet/amazing3-be/assets/71186266/5ffa210b-8bbd-427b-85d9-d6d62028bf5d)

- 우선 deadline을 기준으로 오름차순 정렬하고, 
- deadline이 같은 경우엔 createdAt 내림차순으로 정렬합니다. 

<br>

그리고 GoalService에 메서드가 6개가 되며, 클래스가 너무 길어져 Read Method들을 GoalReadService로 분리했습니다.