### PR TITLE
[🌎 Feature] 한 유저의 Goal과 Task의 최대 갯수를 50개로 제한

### DIFF
--- a/backend/application/api/src/main/kotlin/io/raemian/api/goal/GoalService.kt
+++ b/backend/application/api/src/main/kotlin/io/raemian/api/goal/GoalService.kt
@@ -61,7 +61,7 @@ class GoalService(
         val deadline = RaemianLocalDate.of(yearOfDeadline, monthOfDeadLine)
         val sticker = stickerService.getById(stickerId)
         val tag = tagService.getById(tagId)
-        return Goal(lifeMap, title, deadline, sticker, tag, description!!, emptyList())
+        return Goal(lifeMap, title, deadline, sticker, tag, description!!)
     }
 
     private fun validateLifeMapPublic(lifeMap: LifeMap) {

--- a/backend/application/api/src/main/kotlin/io/raemian/api/goal/GoalService.kt
+++ b/backend/application/api/src/main/kotlin/io/raemian/api/goal/GoalService.kt
@@ -61,6 +61,7 @@ class GoalService(
     }
 
     private fun validateMaxGoalCount(lifeMap: LifeMap) {
+        println(lifeMap.goals.size)
         if (lifeMap.goals.size >= MAX_GOAL_COUNT) {
             throw MaxGoalCountExceededException()
         }

--- a/backend/application/api/src/main/kotlin/io/raemian/api/support/error/ErrorInfo.kt
+++ b/backend/application/api/src/main/kotlin/io/raemian/api/support/error/ErrorInfo.kt
@@ -29,4 +29,11 @@ enum class ErrorInfo(
         "목표 최대 갯수를 초과했습니다.",
         LogLevel.INFO,
     ),
+
+    MAX_TASK_COUNT_EXCEEDED_EXCEPTION(
+        HttpStatus.BAD_REQUEST,
+        1003,
+        "세부 목표의 최대 갯수를 초과했습니다.",
+        LogLevel.INFO,
+    ),
 }

--- a/backend/application/api/src/main/kotlin/io/raemian/api/support/error/ErrorInfo.kt
+++ b/backend/application/api/src/main/kotlin/io/raemian/api/support/error/ErrorInfo.kt
@@ -22,4 +22,11 @@ enum class ErrorInfo(
         "유저의 인생 지도가 비공개 상태입니다.",
         LogLevel.INFO,
     ),
+
+    MAX_GOAL_COUNT_EXCEEDED_EXCEPTION(
+        HttpStatus.BAD_REQUEST,
+        1002,
+        "목표 최대 갯수를 초과했습니다.",
+        LogLevel.INFO,
+    ),
 }

--- a/backend/application/api/src/main/kotlin/io/raemian/api/support/error/MaxGoalCountExceededException.kt
+++ b/backend/application/api/src/main/kotlin/io/raemian/api/support/error/MaxGoalCountExceededException.kt
@@ -1,0 +1,5 @@
+package io.raemian.api.support.error
+
+class MaxGoalCountExceededException : CoreApiException(
+    ErrorInfo.MAX_GOAL_COUNT_EXCEEDED_EXCEPTION,
+)

--- a/backend/application/api/src/main/kotlin/io/raemian/api/support/error/MaxTaskCountExceededException.kt
+++ b/backend/application/api/src/main/kotlin/io/raemian/api/support/error/MaxTaskCountExceededException.kt
@@ -1,0 +1,5 @@
+package io.raemian.api.support.error
+
+class MaxTaskCountExceededException : CoreApiException(
+    ErrorInfo.MAX_TASK_COUNT_EXCEEDED_EXCEPTION,
+)

--- a/backend/application/api/src/main/kotlin/io/raemian/api/task/TaskService.kt
+++ b/backend/application/api/src/main/kotlin/io/raemian/api/task/TaskService.kt
@@ -1,5 +1,7 @@
 package io.raemian.api.task
 
+import io.raemian.api.support.error.MaxGoalCountExceededException
+import io.raemian.api.support.error.MaxTaskCountExceededException
 import io.raemian.api.task.controller.request.CreateTaskRequest
 import io.raemian.api.task.controller.request.RewriteTaskRequest
 import io.raemian.api.task.controller.request.UpdateTaskCompletionRequest
@@ -23,6 +25,7 @@ class TaskService(
         validateCurrentUserIsGoalOwner(currentUserId, goal)
 
         val task = Task.createTask(goal, createTaskRequest.description)
+        addNewTask(goal, task)
         taskRepository.save(task)
         return CreateTaskResponse(task.id!!, task.description)
     }
@@ -60,6 +63,14 @@ class TaskService(
     private fun validateCurrentUserIsGoalOwner(currentUserId: Long, goal: Goal) {
         if (currentUserId != goal.lifeMap.user.id) {
             throw SecurityException()
+        }
+    }
+
+    private fun addNewTask(goal: Goal, task: Task) {
+        try {
+            goal.addTask(task)
+        } catch (exception: IllegalArgumentException) {
+            throw MaxTaskCountExceededException()
         }
     }
 }

--- a/backend/application/api/src/main/kotlin/io/raemian/api/task/TaskService.kt
+++ b/backend/application/api/src/main/kotlin/io/raemian/api/task/TaskService.kt
@@ -1,6 +1,5 @@
 package io.raemian.api.task
 
-import io.raemian.api.support.error.MaxGoalCountExceededException
 import io.raemian.api.support.error.MaxTaskCountExceededException
 import io.raemian.api.task.controller.request.CreateTaskRequest
 import io.raemian.api.task.controller.request.RewriteTaskRequest

--- a/backend/application/api/src/main/kotlin/io/raemian/api/task/TaskService.kt
+++ b/backend/application/api/src/main/kotlin/io/raemian/api/task/TaskService.kt
@@ -26,6 +26,7 @@ class TaskService(
 
         val task = Task.createTask(goal, createTaskRequest.description)
         addNewTask(goal, task)
+
         taskRepository.save(task)
         return CreateTaskResponse(task.id!!, task.description)
     }

--- a/backend/application/api/src/test/kotlin/io/raemian/api/integration/goal/GoalServiceTest.kt
+++ b/backend/application/api/src/test/kotlin/io/raemian/api/integration/goal/GoalServiceTest.kt
@@ -14,7 +14,6 @@ import io.raemian.storage.db.core.user.Authority
 import io.raemian.storage.db.core.user.User
 import io.raemian.storage.db.core.user.enums.OAuthProvider
 import jakarta.persistence.EntityManager
-import org.antlr.v4.runtime.IntStream
 import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertAll
@@ -114,6 +113,39 @@ class GoalServiceTest {
     }
 
     @Test
+    @DisplayName("Goal을 생성할 수 있다.")
+    @Transactional
+    fun createGoalTest() {
+        val createGoalRequest = CreateGoalRequest(
+            title = "title",
+            description = "description",
+            stickerId = STICKER_FIXTURE.id!!,
+            tagId = TAG_FIXTURE.id!!,
+            yearOfDeadline = "2023",
+            monthOfDeadline = "12",
+        )
+
+        val createResponse = goalService.create(
+            userId = USER_FIXTURE.id!!,
+            createGoalRequest = createGoalRequest,
+        )
+
+        val goal = goalRepository.getById(createResponse.id)
+        assertAll(
+            Executable {
+                assertThat(goal.title).isEqualTo(createGoalRequest.title)
+                assertThat(goal.description).isEqualTo(createGoalRequest.description)
+                assertThat(goal.sticker.id).isEqualTo(createGoalRequest.stickerId)
+                assertThat(goal.tag.id).isEqualTo(createGoalRequest.tagId)
+                assertThat(goal.deadline.year.toString())
+                    .isEqualTo(createGoalRequest.yearOfDeadline)
+                assertThat(goal.deadline.monthValue.toString())
+                    .isEqualTo(createGoalRequest.monthOfDeadline)
+            },
+        )
+    }
+
+    @Test
     @DisplayName("목표 생성시 LifeMap의 목표가 50개 이상이라면 예외를 발생시킨다.")
     @Transactional
     fun validateMaxGoalCountTest() {
@@ -146,39 +178,6 @@ class GoalServiceTest {
         Assertions.assertThatThrownBy {
             goalService.create(USER_FIXTURE.id!!, createGoalRequest)
         }.isInstanceOf(MaxGoalCountExceededException::class.java)
-    }
-
-    @Test
-    @DisplayName("Goal을 생성할 수 있다.")
-    @Transactional
-    fun createGoalTest() {
-        val createGoalRequest = CreateGoalRequest(
-            title = "title",
-            description = "description",
-            stickerId = STICKER_FIXTURE.id!!,
-            tagId = TAG_FIXTURE.id!!,
-            yearOfDeadline = "2023",
-            monthOfDeadline = "12",
-        )
-
-        val createResponse = goalService.create(
-            userId = USER_FIXTURE.id!!,
-            createGoalRequest = createGoalRequest,
-        )
-
-        val goal = goalRepository.getById(createResponse.id)
-        assertAll(
-            Executable {
-                assertThat(goal.title).isEqualTo(createGoalRequest.title)
-                assertThat(goal.description).isEqualTo(createGoalRequest.description)
-                assertThat(goal.sticker.id).isEqualTo(createGoalRequest.stickerId)
-                assertThat(goal.tag.id).isEqualTo(createGoalRequest.tagId)
-                assertThat(goal.deadline.year.toString())
-                    .isEqualTo(createGoalRequest.yearOfDeadline)
-                assertThat(goal.deadline.monthValue.toString())
-                    .isEqualTo(createGoalRequest.monthOfDeadline)
-            },
-        )
     }
 
     @Test

--- a/backend/application/api/src/test/kotlin/io/raemian/api/integration/goal/GoalServiceTest.kt
+++ b/backend/application/api/src/test/kotlin/io/raemian/api/integration/goal/GoalServiceTest.kt
@@ -78,7 +78,6 @@ class GoalServiceTest {
             sticker = STICKER_FIXTURE,
             tag = TAG_FIXTURE,
             description = "내용",
-            tasks = emptyList(),
         )
         goalRepository.save(goal)
 
@@ -104,7 +103,6 @@ class GoalServiceTest {
             sticker = STICKER_FIXTURE,
             tag = TAG_FIXTURE,
             description = "목표 설명.",
-            tasks = emptyList(),
         )
         goalRepository.save(goal)
 
@@ -195,7 +193,6 @@ class GoalServiceTest {
             deadline = LocalDate.now(),
             sticker = STICKER_FIXTURE,
             tag = TAG_FIXTURE,
-            tasks = emptyList(),
         )
 
         goalRepository.save(goal)
@@ -215,7 +212,6 @@ class GoalServiceTest {
             sticker = STICKER_FIXTURE,
             tag = TAG_FIXTURE,
             description = "목표 설명",
-            tasks = emptyList(),
         )
 
         lifeMap.addGoal(goal)

--- a/backend/application/api/src/test/kotlin/io/raemian/api/integration/goal/GoalServiceTest.kt
+++ b/backend/application/api/src/test/kotlin/io/raemian/api/integration/goal/GoalServiceTest.kt
@@ -28,7 +28,6 @@ import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
 
 @SpringBootTest
-@Transactional
 class GoalServiceTest {
 
     companion object {
@@ -121,7 +120,6 @@ class GoalServiceTest {
     @Transactional
     fun validateMaxGoalCountTest() {
         // given
-//        val lifeMap = LifeMap(USER_FIXTURE, true)
         val lifeMap = entityManager.find(LifeMap::class.java, LIFE_MAP_FIXTURE.id)
         val createGoalRequest = CreateGoalRequest(
             title = "title",
@@ -154,6 +152,7 @@ class GoalServiceTest {
 
     @Test
     @DisplayName("Goal을 생성할 수 있다.")
+    @Transactional
     fun createGoalTest() {
         val createGoalRequest = CreateGoalRequest(
             title = "title",

--- a/backend/application/api/src/test/kotlin/io/raemian/api/integration/lifemap/LifeMapServiceTest.kt
+++ b/backend/application/api/src/test/kotlin/io/raemian/api/integration/lifemap/LifeMapServiceTest.kt
@@ -72,7 +72,6 @@ class LifeMapServiceTest {
             sticker = STICKER_FIXTURE,
             tag = TAG_FIXTURE,
             description = "",
-            tasks = emptyList(),
         )
 
         val goal2 = Goal(
@@ -82,7 +81,6 @@ class LifeMapServiceTest {
             sticker = STICKER_FIXTURE,
             tag = TAG_FIXTURE,
             description = "",
-            tasks = emptyList(),
         )
         val lifeMap = lifeMapRepository.findFirstByUserId(USER_FIXTURE.id!!)
             ?: fail()
@@ -115,7 +113,6 @@ class LifeMapServiceTest {
             sticker = STICKER_FIXTURE,
             tag = TAG_FIXTURE,
             description = "",
-            tasks = emptyList(),
         )
 
         val goal2 = Goal(
@@ -125,7 +122,6 @@ class LifeMapServiceTest {
             sticker = STICKER_FIXTURE,
             tag = TAG_FIXTURE,
             description = "",
-            tasks = emptyList(),
         )
         val lifeMap = lifeMapRepository.findFirstByUserId(USER_FIXTURE.id!!)
             ?: fail()
@@ -173,7 +169,6 @@ class LifeMapServiceTest {
             sticker = STICKER_FIXTURE,
             tag = TAG_FIXTURE,
             description = "",
-            tasks = emptyList(),
         )
 
         val goal2 = Goal(
@@ -183,7 +178,6 @@ class LifeMapServiceTest {
             sticker = STICKER_FIXTURE,
             tag = TAG_FIXTURE,
             description = "",
-            tasks = emptyList(),
         )
         val lifeMap = lifeMapRepository.findFirstByUserId(USER_FIXTURE.id!!)
             ?: fail()
@@ -221,7 +215,6 @@ class LifeMapServiceTest {
             sticker = STICKER_FIXTURE,
             tag = TAG_FIXTURE,
             description = "",
-            tasks = emptyList(),
         )
 
         val deadline이_내일이고_가장_나중에_만들어진_객체 = Goal(
@@ -232,7 +225,6 @@ class LifeMapServiceTest {
             sticker = STICKER_FIXTURE,
             tag = TAG_FIXTURE,
             description = "",
-            tasks = emptyList(),
         )
 
         val deadline이_오늘인_객체 = Goal(
@@ -242,7 +234,6 @@ class LifeMapServiceTest {
             sticker = STICKER_FIXTURE,
             tag = TAG_FIXTURE,
             description = "",
-            tasks = emptyList(),
         )
 
         // when

--- a/backend/application/api/src/test/kotlin/io/raemian/api/integration/task/TaskServiceTest.kt
+++ b/backend/application/api/src/test/kotlin/io/raemian/api/integration/task/TaskServiceTest.kt
@@ -49,7 +49,6 @@ class TaskServiceTest {
             sticker = STICKER_FIXTURE,
             tag = TAG_FIXTURE,
             description = "description",
-            tasks = emptyList(),
         )
     }
 

--- a/backend/storage/db-core/src/main/kotlin/io/raemian/storage/db/core/goal/Goal.kt
+++ b/backend/storage/db-core/src/main/kotlin/io/raemian/storage/db/core/goal/Goal.kt
@@ -55,7 +55,15 @@ class Goal(
     val id: Long? = null,
 ) : BaseEntity() {
 
+    companion object {
+        private const val MAX_TASK_COUNT = 50
+    }
+
     fun addTask(task: Task) {
+        validateMaxTaskCount()
         tasks.add(task)
     }
+
+    private fun validateMaxTaskCount() =
+        require(tasks.size < MAX_TASK_COUNT)
 }

--- a/backend/storage/db-core/src/main/kotlin/io/raemian/storage/db/core/goal/Goal.kt
+++ b/backend/storage/db-core/src/main/kotlin/io/raemian/storage/db/core/goal/Goal.kt
@@ -45,7 +45,8 @@ class Goal(
     val description: String = "",
 
     @OneToMany(
-        mappedBy = "goal", cascade = [CascadeType.REMOVE, CascadeType.MERGE],
+        mappedBy = "goal",
+        cascade = [CascadeType.REMOVE, CascadeType.MERGE],
         fetch = FetchType.LAZY,
     )
     val tasks: MutableList<Task> = ArrayList(),

--- a/backend/storage/db-core/src/main/kotlin/io/raemian/storage/db/core/goal/Goal.kt
+++ b/backend/storage/db-core/src/main/kotlin/io/raemian/storage/db/core/goal/Goal.kt
@@ -44,10 +44,18 @@ class Goal(
     @Nationalized
     val description: String = "",
 
-    @OneToMany(mappedBy = "goal", cascade = [CascadeType.REMOVE], fetch = FetchType.LAZY)
-    val tasks: List<Task>,
+    @OneToMany(
+        mappedBy = "goal", cascade = [CascadeType.REMOVE, CascadeType.MERGE],
+        fetch = FetchType.LAZY,
+    )
+    val tasks: MutableList<Task> = ArrayList(),
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long? = null,
-) : BaseEntity()
+) : BaseEntity() {
+
+    fun addTask(task: Task) {
+        tasks.add(task)
+    }
+}

--- a/backend/storage/db-core/src/main/kotlin/io/raemian/storage/db/core/lifemap/LifeMap.kt
+++ b/backend/storage/db-core/src/main/kotlin/io/raemian/storage/db/core/lifemap/LifeMap.kt
@@ -37,11 +37,16 @@ class LifeMap(
     val id: Long? = null,
 ) : BaseEntity() {
 
+    companion object {
+        private const val MAX_GOAL_COUNT = 50
+    }
+
     fun updatePublic(isPublic: Boolean) {
         this.isPublic = isPublic
     }
 
     fun addGoal(goal: Goal) {
+        validateMaxGoalCount()
         this.goals.add(goal)
     }
 
@@ -51,4 +56,7 @@ class LifeMap(
                 .thenByDescending { it.createdAt },
         )
     }
+
+    private fun validateMaxGoalCount() =
+        require(goals.size < MAX_GOAL_COUNT)
 }


### PR DESCRIPTION
## 📒 Issue
#151 

<br>

- Goal 갯수가 50개 이상일 때, Goal 생성을 요청하는 경우 예외를 발생시킨다.
- Task 갯수가 50개 이상일 때, Task 생성을 요청하는 경우 예외를 발생시킨다.
- Goal에 Task를 추가할 때, TaskService가 아닌 Goal이 스스로 추가하도록 변경
- 새로 작성한 부분들에 대한 테스트 코드 작성
