### PR TITLE
[🌎 Feature] Goal 정보 수정하기 API 

### DIFF
--- a/backend/application/api/src/main/kotlin/io/raemian/api/config/GlobalExceptionHandler.kt
+++ b/backend/application/api/src/main/kotlin/io/raemian/api/config/GlobalExceptionHandler.kt
@@ -4,6 +4,7 @@ import io.raemian.api.log.LogService
 import io.raemian.api.support.error.CoreApiException
 import io.raemian.api.support.error.ErrorInfo
 import io.raemian.api.support.response.ApiResponse
+import jakarta.persistence.EntityNotFoundException
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.http.ResponseEntity
@@ -20,6 +21,15 @@ class GlobalExceptionHandler(
     fun handleCoreApiException(e: CoreApiException): ResponseEntity<ApiResponse<Any>> {
         log.error("Exception : {}", e.message, e)
         return ResponseEntity(ApiResponse.error(e.errorInfo), e.errorInfo.status)
+    }
+
+    @ExceptionHandler(NoSuchElementException::class, EntityNotFoundException::class)
+    fun handleResourceNotFoundException(e: CoreApiException): ResponseEntity<ApiResponse<Any>> {
+        log.error("Exception : {}", e.message, e)
+        return ResponseEntity(
+            ApiResponse.error(ErrorInfo.RESOURCE_NOT_FOUND),
+            ErrorInfo.RESOURCE_NOT_FOUND.status,
+        )
     }
 
     @ExceptionHandler(Exception::class)

--- a/backend/application/api/src/main/kotlin/io/raemian/api/goal/GoalService.kt
+++ b/backend/application/api/src/main/kotlin/io/raemian/api/goal/GoalService.kt
@@ -56,6 +56,7 @@ class GoalService(
 
             val deadline = RaemianLocalDate.of(yearOfDeadline, monthOfDeadline)
             goal.update(title, deadline, description)
+            goalRepository.save(goal)
         }
         return GoalResponse(goal)
     }
@@ -75,8 +76,8 @@ class GoalService(
     private fun createGoal(createGoalRequest: CreateGoalRequest, lifeMap: LifeMap): Goal {
         with(createGoalRequest) {
             val deadline = RaemianLocalDate.of(yearOfDeadline, monthOfDeadline)
-            val sticker = stickerService.getById(stickerId)
-            val tag = tagService.getById(tagId)
+            val sticker = stickerService.getReferenceById(stickerId)
+            val tag = tagService.getReferenceById(tagId)
             return Goal(lifeMap, title, deadline, sticker, tag, description!!)
         }
     }
@@ -103,14 +104,14 @@ class GoalService(
 
     private fun updateTag(goal: Goal, tagId: Long) {
         if (goal.tag.id != tagId) {
-            val newTag = tagService.getById(tagId)
+            val newTag = tagService.getReferenceById(tagId)
             goal.updateTag(newTag)
         }
     }
 
     private fun updateSticker(goal: Goal, stickerId: Long) {
         if (goal.sticker.id != stickerId) {
-            val newSticker = stickerService.getById(stickerId)
+            val newSticker = stickerService.getReferenceById(stickerId)
             goal.updateSticker(newSticker)
         }
     }

--- a/backend/application/api/src/main/kotlin/io/raemian/api/goal/GoalService.kt
+++ b/backend/application/api/src/main/kotlin/io/raemian/api/goal/GoalService.kt
@@ -1,6 +1,7 @@
 package io.raemian.api.goal
 
 import io.raemian.api.goal.controller.request.CreateGoalRequest
+import io.raemian.api.goal.controller.request.UpdateGoalRequest
 import io.raemian.api.goal.controller.response.CreateGoalResponse
 import io.raemian.api.goal.controller.response.GoalResponse
 import io.raemian.api.sticker.StickerService
@@ -45,6 +46,21 @@ class GoalService(
     }
 
     @Transactional
+    fun update(userId: Long, goalId: Long, updateGoalRequest: UpdateGoalRequest): GoalResponse {
+        val goal = goalRepository.getById(goalId)
+        validateGoalIsUsers(userId, goal)
+
+        with(updateGoalRequest) {
+            updateTag(goal, tagId)
+            updateSticker(goal, stickerId)
+
+            val deadline = RaemianLocalDate.of(yearOfDeadline, monthOfDeadline)
+            goal.update(title, deadline, description)
+        }
+        return GoalResponse(goal)
+    }
+
+    @Transactional
     fun delete(userId: Long, goalId: Long) {
         val goal = goalRepository.getById(goalId)
         validateGoalIsUsers(userId, goal)
@@ -81,6 +97,20 @@ class GoalService(
             lifeMap.addGoal(goal)
         } catch (exception: IllegalArgumentException) {
             throw MaxGoalCountExceededException()
+        }
+    }
+
+    private fun updateTag(goal: Goal, tagId: Long) {
+        if (goal.tag.id != tagId) {
+            val newTag = tagService.getById(tagId)
+            goal.updateTag(newTag)
+        }
+    }
+
+    private fun updateSticker(goal: Goal, stickerId: Long) {
+        if (goal.sticker.id != stickerId) {
+            val newSticker = stickerService.getById(stickerId)
+            goal.updateSticker(newSticker)
         }
     }
 }

--- a/backend/application/api/src/main/kotlin/io/raemian/api/goal/GoalService.kt
+++ b/backend/application/api/src/main/kotlin/io/raemian/api/goal/GoalService.kt
@@ -69,8 +69,12 @@ class GoalService(
     }
 
     private fun createFirstLifeMap(userId: Long): LifeMap {
-        val user = userRepository.getById(userId)
-        return LifeMap(user, true, goals = ArrayList())
+        val user = userRepository.getReferenceById(userId)
+        return LifeMap(
+            user = user,
+            isPublic = true,
+            goals = ArrayList(),
+        )
     }
 
     private fun createGoal(createGoalRequest: CreateGoalRequest, lifeMap: LifeMap): Goal {

--- a/backend/application/api/src/main/kotlin/io/raemian/api/goal/GoalService.kt
+++ b/backend/application/api/src/main/kotlin/io/raemian/api/goal/GoalService.kt
@@ -73,11 +73,12 @@ class GoalService(
     }
 
     private fun createGoal(createGoalRequest: CreateGoalRequest, lifeMap: LifeMap): Goal {
-        val (title, yearOfDeadline, monthOfDeadLine, stickerId, tagId, description) = createGoalRequest
-        val deadline = RaemianLocalDate.of(yearOfDeadline, monthOfDeadLine)
-        val sticker = stickerService.getById(stickerId)
-        val tag = tagService.getById(tagId)
-        return Goal(lifeMap, title, deadline, sticker, tag, description!!)
+        with(createGoalRequest) {
+            val deadline = RaemianLocalDate.of(yearOfDeadline, monthOfDeadline)
+            val sticker = stickerService.getById(stickerId)
+            val tag = tagService.getById(tagId)
+            return Goal(lifeMap, title, deadline, sticker, tag, description!!)
+        }
     }
 
     private fun validateAnotherUserLifeMapPublic(userId: Long, lifeMap: LifeMap) {

--- a/backend/application/api/src/main/kotlin/io/raemian/api/goal/controller/GoalController.kt
+++ b/backend/application/api/src/main/kotlin/io/raemian/api/goal/controller/GoalController.kt
@@ -3,6 +3,7 @@ package io.raemian.api.goal.controller
 import io.raemian.api.auth.domain.CurrentUser
 import io.raemian.api.goal.GoalService
 import io.raemian.api.goal.controller.request.CreateGoalRequest
+import io.raemian.api.goal.controller.request.UpdateGoalRequest
 import io.raemian.api.goal.controller.response.CreateGoalResponse
 import io.raemian.api.goal.controller.response.GoalResponse
 import io.raemian.api.support.response.ApiResponse
@@ -11,6 +12,7 @@ import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -46,6 +48,18 @@ class GoalController(
         return ResponseEntity
             .created("/goal/${response.id}".toUri())
             .body(ApiResponse.success(response))
+    }
+
+    @Operation(summary = "목표 수정 API")
+    @PatchMapping("/{goalId}")
+    fun update(
+        @AuthenticationPrincipal currentUser: CurrentUser,
+        @PathVariable("goalId") goalId: Long,
+        @RequestBody updateGoalRequest: UpdateGoalRequest,
+    ): ResponseEntity<ApiResponse<GoalResponse>> {
+        val goalResponse = goalService.update(currentUser.id, goalId, updateGoalRequest)
+        return ResponseEntity
+            .ok(ApiResponse.success(goalResponse))
     }
 
     @Operation(summary = "목표 삭제 API")

--- a/backend/application/api/src/main/kotlin/io/raemian/api/goal/controller/request/UpdateGoalRequest.kt
+++ b/backend/application/api/src/main/kotlin/io/raemian/api/goal/controller/request/UpdateGoalRequest.kt
@@ -1,0 +1,10 @@
+package io.raemian.api.goal.controller.request
+
+data class UpdateGoalRequest(
+    val title: String,
+    val yearOfDeadline: String,
+    val monthOfDeadline: String,
+    val stickerId: Long,
+    val tagId: Long,
+    val description: String,
+)

--- a/backend/application/api/src/main/kotlin/io/raemian/api/sticker/StickerService.kt
+++ b/backend/application/api/src/main/kotlin/io/raemian/api/sticker/StickerService.kt
@@ -18,7 +18,7 @@ class StickerService(
     }
 
     @Transactional(readOnly = true)
-    fun getById(id: Long): Sticker {
-        return stickerRepository.getById(id)
+    fun getReferenceById(id: Long): Sticker {
+        return stickerRepository.getReferenceById(id)
     }
 }

--- a/backend/application/api/src/main/kotlin/io/raemian/api/support/error/ErrorInfo.kt
+++ b/backend/application/api/src/main/kotlin/io/raemian/api/support/error/ErrorInfo.kt
@@ -16,6 +16,13 @@ enum class ErrorInfo(
         LogLevel.ERROR,
     ),
 
+    RESOURCE_NOT_FOUND(
+        HttpStatus.NOT_FOUND,
+        HttpStatus.NOT_FOUND.value(),
+        "Resource Not Found",
+        LogLevel.ERROR,
+    ),
+
     PRIVATE_LIFE_MAP_EXCEPTION(
         HttpStatus.FORBIDDEN,
         1001,
@@ -36,6 +43,7 @@ enum class ErrorInfo(
         "세부 목표의 최대 갯수를 초과했습니다.",
         LogLevel.INFO,
     ),
+
     TOO_MANY_CHEERING(
         HttpStatus.TOO_MANY_REQUESTS,
         1004,

--- a/backend/application/api/src/main/kotlin/io/raemian/api/tag/TagService.kt
+++ b/backend/application/api/src/main/kotlin/io/raemian/api/tag/TagService.kt
@@ -18,7 +18,7 @@ class TagService(
     }
 
     @Transactional(readOnly = true)
-    fun getById(id: Long): Tag {
-        return tagRepository.getById(id)
+    fun getReferenceById(id: Long): Tag {
+        return tagRepository.getReferenceById(id)
     }
 }

--- a/backend/application/api/src/test/kotlin/io/raemian/api/integration/goal/GoalServiceTest.kt
+++ b/backend/application/api/src/test/kotlin/io/raemian/api/integration/goal/GoalServiceTest.kt
@@ -251,13 +251,13 @@ class GoalServiceTest {
         goalService.update(USER_FIXTURE.id!!, goal.id!!, updateGoalRequest)
 
         // then
-        val findById = goalRepository.getById(goal.id!!)
-        assertThat(findById.title).isEqualTo(newTitle)
-        assertThat(findById.description).isEqualTo(newDescription)
-        assertThat(findById.deadline.year).isEqualTo(newDeadline.year)
-        assertThat(findById.deadline.month).isEqualTo(newDeadline.month)
-        assertThat(findById.sticker.name).isEqualTo(newSticker.name)
-        assertThat(findById.tag.content).isEqualTo(newTag.content)
+        val updatedGoal = goalRepository.getById(goal.id!!)
+        assertThat(updatedGoal.title).isEqualTo(newTitle)
+        assertThat(updatedGoal.description).isEqualTo(newDescription)
+        assertThat(updatedGoal.deadline.year).isEqualTo(newDeadline.year)
+        assertThat(updatedGoal.deadline.month).isEqualTo(newDeadline.month)
+        assertThat(updatedGoal.sticker.name).isEqualTo(newSticker.name)
+        assertThat(updatedGoal.tag.content).isEqualTo(newTag.content)
     }
 
     @Test

--- a/backend/application/api/src/test/kotlin/io/raemian/api/integration/goal/GoalServiceTest.kt
+++ b/backend/application/api/src/test/kotlin/io/raemian/api/integration/goal/GoalServiceTest.kt
@@ -222,6 +222,7 @@ class GoalServiceTest {
             sticker = STICKER_FIXTURE,
             tag = TAG_FIXTURE,
         )
+        goalRepository.save(goal)
 
         // when
         val newTitle = "New" + title
@@ -232,14 +233,12 @@ class GoalServiceTest {
             "New" + STICKER_FIXTURE.url,
         )
         val newTag = Tag("New" + TAG_FIXTURE.content)
+        entityManager.merge(newSticker)
+        entityManager.merge(newTag)
 
         val newDeadline = deadline.plusDays(77)
         val newYear = newDeadline.year.toString()
         val newMonth = newDeadline.monthValue.toString()
-
-        entityManager.merge(newSticker)
-        entityManager.merge(newTag)
-        goalRepository.save(goal)
 
         val updateGoalRequest = UpdateGoalRequest(
             title = newTitle,

--- a/backend/storage/db-core/src/main/kotlin/io/raemian/storage/db/core/goal/Goal.kt
+++ b/backend/storage/db-core/src/main/kotlin/io/raemian/storage/db/core/goal/Goal.kt
@@ -71,7 +71,6 @@ class Goal(
         description: String,
     ): Goal = Goal(lifeMap, title, deadline, sticker, tag, description, tasks, id)
 
-
     fun updateSticker(sticker: Sticker): Goal =
         Goal(lifeMap, title, deadline, sticker, tag, description, tasks, id)
 

--- a/backend/storage/db-core/src/main/kotlin/io/raemian/storage/db/core/goal/Goal.kt
+++ b/backend/storage/db-core/src/main/kotlin/io/raemian/storage/db/core/goal/Goal.kt
@@ -28,21 +28,21 @@ class Goal(
 
     @Column(nullable = false)
     @Nationalized
-    val title: String,
+    var title: String,
 
     @Column(nullable = false)
-    val deadline: LocalDate,
+    var deadline: LocalDate,
 
     @ManyToOne
     @JoinColumn(name = "sticker_id", nullable = false)
-    val sticker: Sticker,
+    var sticker: Sticker,
 
     @ManyToOne
     @JoinColumn(name = "tag_id", nullable = false)
-    val tag: Tag,
+    var tag: Tag,
 
     @Nationalized
-    val description: String = "",
+    var description: String = "",
 
     @OneToMany(
         mappedBy = "goal",
@@ -63,6 +63,24 @@ class Goal(
     fun addTask(task: Task) {
         validateMaxTaskCount()
         tasks.add(task)
+    }
+
+    fun update(
+        title: String,
+        deadline: LocalDate,
+        description: String,
+    ) {
+        this.title = title
+        this.deadline = deadline
+        this.description = description
+    }
+
+    fun updateSticker(sticker: Sticker) {
+        this.sticker = sticker
+    }
+
+    fun updateTag(tag: Tag) {
+        this.tag = tag
     }
 
     private fun validateMaxTaskCount() =

--- a/backend/storage/db-core/src/main/kotlin/io/raemian/storage/db/core/goal/Goal.kt
+++ b/backend/storage/db-core/src/main/kotlin/io/raemian/storage/db/core/goal/Goal.kt
@@ -69,19 +69,14 @@ class Goal(
         title: String,
         deadline: LocalDate,
         description: String,
-    ) {
-        this.title = title
-        this.deadline = deadline
-        this.description = description
-    }
+    ): Goal = Goal(lifeMap, title, deadline, sticker, tag, description, tasks, id)
 
-    fun updateSticker(sticker: Sticker) {
-        this.sticker = sticker
-    }
 
-    fun updateTag(tag: Tag) {
-        this.tag = tag
-    }
+    fun updateSticker(sticker: Sticker): Goal =
+        Goal(lifeMap, title, deadline, sticker, tag, description, tasks, id)
+
+    fun updateTag(tag: Tag): Goal =
+        Goal(lifeMap, title, deadline, sticker, tag, description, tasks, id)
 
     private fun validateMaxTaskCount() =
         require(tasks.size < MAX_TASK_COUNT)


### PR DESCRIPTION
## 📒 Issue
#169

## 🎯 어떤 작업을 했는지
Goal의 update API를 구현하고, 테스트를 작성했습니다.

- DB Read를 줄이기 위해, sticker와 tag는 id 값 확인을 통해, <br> 수정 전의 상태와 다를 경우에만 update합니다. <br> 이를 위해 Goal update 메서드가 3개로 나뉘었습니다. <br> 태그 수정, 스티커 수정, 나머지 수정 (title, description, deadline)
- 비구조화 할당 대신 with 처음 써 봤는데, 가독성 측면에서 뭐가 더 나은지 봐주세요