### PR TITLE
[🌎 Feature] Goal 조회 API에 자신의 Goal 소유 여부 필드 추가

### DIFF
--- a/backend/application/api/src/main/kotlin/io/raemian/api/goal/GoalService.kt
+++ b/backend/application/api/src/main/kotlin/io/raemian/api/goal/GoalService.kt
@@ -29,8 +29,9 @@ class GoalService(
     @Transactional(readOnly = true)
     fun getById(id: Long, userId: Long): GoalResponse {
         val goal = goalRepository.getById(id)
-        validateAnotherUserLifeMapPublic(userId, goal.lifeMap)
-        return GoalResponse(goal)
+        val isMyGoal = goal.lifeMap.user.id != userId
+        validateAnotherUserLifeMapPublic(isMyGoal, goal.lifeMap)
+        return GoalResponse(goal, isMyGoal)
     }
 
     @Transactional
@@ -60,7 +61,7 @@ class GoalService(
             val deadline = RaemianLocalDate.of(yearOfDeadline, monthOfDeadline)
             val updatedGoal = updatedStickerGoal.update(title, deadline, description)
             goalRepository.save(updatedGoal)
-            return GoalResponse(updatedGoal)
+            return GoalResponse(updatedGoal, true)
         }
     }
 
@@ -89,8 +90,8 @@ class GoalService(
         }
     }
 
-    private fun validateAnotherUserLifeMapPublic(userId: Long, lifeMap: LifeMap) {
-        if (lifeMap.user.id != userId && !lifeMap.isPublic) {
+    private fun validateAnotherUserLifeMapPublic(isMyGoal: Boolean, lifeMap: LifeMap) {
+        if (!isMyGoal && !lifeMap.isPublic) {
             throw PrivateLifeMapException()
         }
     }

--- a/backend/application/api/src/main/kotlin/io/raemian/api/goal/GoalService.kt
+++ b/backend/application/api/src/main/kotlin/io/raemian/api/goal/GoalService.kt
@@ -29,7 +29,7 @@ class GoalService(
     @Transactional(readOnly = true)
     fun getById(id: Long, userId: Long): GoalResponse {
         val goal = goalRepository.getById(id)
-        val isMyGoal = goal.lifeMap.user.id != userId
+        val isMyGoal = goal.lifeMap.user.id == userId
         validateAnotherUserLifeMapPublic(isMyGoal, goal.lifeMap)
         return GoalResponse(goal, isMyGoal)
     }

--- a/backend/application/api/src/main/kotlin/io/raemian/api/goal/controller/GoalController.kt
+++ b/backend/application/api/src/main/kotlin/io/raemian/api/goal/controller/GoalController.kt
@@ -30,7 +30,7 @@ class GoalController(
 
     @Operation(summary = "목표 단건 조회 API")
     @GetMapping("/{goalId}")
-    fun getByUserId(
+    fun getById(
         @AuthenticationPrincipal currentUser: CurrentUser,
         @PathVariable("goalId") goalId: Long,
     ): ResponseEntity<ApiResponse<GoalResponse>> =

--- a/backend/application/api/src/main/kotlin/io/raemian/api/goal/controller/response/GoalResponse.kt
+++ b/backend/application/api/src/main/kotlin/io/raemian/api/goal/controller/response/GoalResponse.kt
@@ -11,16 +11,18 @@ data class GoalResponse(
     val deadline: String,
     val stickerUrl: String,
     val tagInfo: TagInfo,
+    val isMyGoal: Boolean,
     val tasks: List<TaskInfo>,
 ) {
 
-    constructor(goal: Goal) : this(
-        goal.title,
-        goal.description,
-        goal.deadline.format(),
-        goal.sticker.url,
-        TagInfo(goal.tag),
-        goal.tasks.map(::TaskInfo),
+    constructor(goal: Goal, isMyGoal: Boolean) : this(
+        title = goal.title,
+        description = goal.description,
+        deadline = goal.deadline.format(),
+        stickerUrl = goal.sticker.url,
+        tagInfo = TagInfo(goal.tag),
+        isMyGoal = isMyGoal,
+        tasks = goal.tasks.map(::TaskInfo),
     )
 
     data class TagInfo(

--- a/backend/application/api/src/test/kotlin/io/raemian/api/integration/goal/GoalServiceTest.kt
+++ b/backend/application/api/src/test/kotlin/io/raemian/api/integration/goal/GoalServiceTest.kt
@@ -136,6 +136,32 @@ class GoalServiceTest {
     }
 
     @Test
+    @DisplayName("목표 조회시, 자신의 목표인지 다른 사람의 목표인지 확인할 수 있다.")
+    @Transactional
+    fun isMyGoalTest() {
+        // given
+        val lifeMap = entityManager.find(LifeMap::class.java, LIFE_MAP_FIXTURE.id)
+
+        val goal = Goal(
+            lifeMap = lifeMap,
+            title = "목표",
+            deadline = LocalDate.MAX,
+            sticker = STICKER_FIXTURE,
+            tag = TAG_FIXTURE,
+            description = "목표 설명.",
+        )
+        goalRepository.save(goal)
+
+        // when
+        val myGoal = goalService.getById(goal.id!!, USER_FIXTURE.id!!)
+        val othersGoal = goalService.getById(goal.id!!, USER_FIXTURE.id!! + 1)
+
+        // then
+        assertThat(myGoal.isMyGoal).isTrue()
+        assertThat(othersGoal.isMyGoal).isFalse()
+    }
+
+    @Test
     @DisplayName("Goal을 생성할 수 있다.")
     @Transactional
     fun createGoalTest() {


### PR DESCRIPTION
<!--
1. Jira
2. 어떤 작업을 했는지 : 간단하게 설명
3. 자세한 설명 : 필요하다면
4. 영향범위 : 영향받은 모듈
-->

## 📒 Issue
#172 

## 🎯 어떤 작업을 했는지
- 클라이언트 단에서, Update 가능 여부를 구분하기 위해, <br>
현재 조회중인 Goal의 소유 여부를 알 필요가 있다. <Br> 이에 Goal API 응답에 isMyGoal 필드를 추가한다.


