### PR TITLE
[🌎 Feature] Goal 이모지 반응 기능

### DIFF
--- a/admin-ui/src/client/emoji.ts
+++ b/admin-ui/src/client/emoji.ts
@@ -1,0 +1,65 @@
+import useSWR from "swr";
+import {fetchApi, uploadApi} from "@/client/base";
+
+const emoji = `emoji`
+
+export interface IEmoji {
+    id: number;
+    name: string;
+    url: string;
+}
+
+export interface IEmojiFormValue extends Omit<IEmoji, "id" | "url"> {
+    image: {
+        file: File
+        fileList: File[]
+    }
+}
+
+export interface IEmojisResponse {
+    result: number;
+    body: IEmoji[]
+    error: {
+        code: string;
+        message: string;
+        data: object;
+    };
+}
+
+export interface IEmojiResponse {
+    result: number;
+    body: IEmoji
+    error: {
+        code: string;
+        message: string;
+        data: object;
+    };
+}
+
+export const useEmojis = () => {
+    return useSWR<IEmojisResponse>(emoji);
+};
+
+export const useEmoji = (id: string | number) => {
+    return useSWR<IEmojiResponse>(`${emoji}/${id}`);
+};
+
+export const createEmoji = (value: IEmojiFormValue) => {
+    const form = new FormData()
+    form.append("name", value.name)
+    form.append("image", value.image.file, value.image.file.name)
+
+    return uploadApi.post(emoji, { body: form });
+};
+
+export const updateEmoji = (id: string, value: IEmojiFormValue) => {
+    const form = new FormData()
+    form.append("name", value.name)
+    form.append("image", value.image.file, value.image.file.name)
+
+    return uploadApi.patch(`${emoji}/${id}`, { body: form });
+};
+
+export const deleteEmoji = (id: string | number) => {
+    return fetchApi.delete(`${emoji}/${id}`);
+};

--- a/admin-ui/src/components/layout/main-menu.tsx
+++ b/admin-ui/src/components/layout/main-menu.tsx
@@ -41,6 +41,20 @@ const mainMenuData: IMenu[] = [
     ],
   },
   {
+    id: "emoji",
+    name: "이모지 관리",
+    icon: <Package2 className="w-5 h-5" />,
+    submenu: [
+      {
+        id: "emojiList",
+        name: "이모지 목록",
+        link: {
+          path: "/emoji/list",
+        },
+      },
+    ],
+  },
+  {
     id: "defaultProfile",
     name: "기본 프로필 관리",
     icon: <Package2 className="w-5 h-5" />,

--- a/admin-ui/src/components/page/emoji/emoji-form.tsx
+++ b/admin-ui/src/components/page/emoji/emoji-form.tsx
@@ -1,0 +1,93 @@
+import DefaultForm from "@/components/shared/form/ui/default-form";
+import FormGroup from "@/components/shared/form/ui/form-group";
+import FormSection from "@/components/shared/form/ui/form-section";
+import {Button, Form, Input, message, Upload, UploadProps} from "antd";
+import { useForm } from "antd/lib/form/Form";
+import React, { useState } from "react";
+import {IEmojiFormValue, updateEmoji, createEmoji} from "@/client/emoji";
+import {UploadOutlined} from "@ant-design/icons";
+
+interface IEmojiFormProps {
+  id?: string;
+  initialValues?: Partial<IEmojiFormValue>;
+}
+
+const EmojiForm = ({ id, initialValues }: IEmojiFormProps) => {
+  const [form] = useForm();
+  const [isLoading, setIsLoading] = useState(false);
+  const [messageApi, contextHolder] = message.useMessage();
+
+
+  const handleFinish = async (formValue: IEmojiFormValue) => {
+    try {
+      setIsLoading(true);
+
+      if (id) {
+        await updateEmoji(id, formValue);
+        messageApi.success("수정되었습니다");
+      } else {
+        await createEmoji(formValue);
+        messageApi.success("생성되었습니다");
+      }
+    } catch (e: unknown) {
+      messageApi.error("에러가 발생했습니다");
+    } finally {
+      setTimeout(() => setIsLoading(false), 500);
+    }
+  };
+
+  const props: UploadProps = {
+    name: 'image',
+    beforeUpload: (file) => {
+      const isPNG = file.type === 'image/png';
+      if (!isPNG) {
+        message.error(`${file.name} is not a png file`);
+      }
+
+      return false;
+    },
+    onChange: (info) => {
+      return info.file;
+    },
+  };
+
+
+  return (
+      <>
+        {contextHolder}
+        <DefaultForm<IEmojiFormValue>
+            form={form}
+            initialValues={{
+              id: id,
+              name: initialValues?.name
+            }}
+            onFinish={handleFinish}
+        >
+          <FormSection title="이모지 수정 폼" description="목표에 설정 가능한 이모지 수정 기능">
+            <FormGroup title="이모지 이름">
+              <Form.Item name="name">
+                <Input.TextArea placeholder="이모지 이름을 적어주세요." rows={1} />
+              </Form.Item>
+            </FormGroup>
+
+            <FormGroup title="PNG 파일">
+              <Form.Item name="image">
+                <Upload action={'/wow/wow'} {...props}>
+                  <Button icon={<UploadOutlined />}>Upload png only</Button>
+                </Upload>
+              </Form.Item>
+            </FormGroup>
+
+          </FormSection>
+
+          <div className="text-center">
+            <Button htmlType="submit" type="primary">
+              제출
+            </Button>
+          </div>
+        </DefaultForm>
+      </>
+  );
+};
+
+export default React.memo(EmojiForm);

--- a/admin-ui/src/components/page/emoji/emoji-list.tsx
+++ b/admin-ui/src/components/page/emoji/emoji-list.tsx
@@ -1,0 +1,156 @@
+import DefaultTable from "@/components/shared/ui/default-table";
+import DefaultTableBtn from "@/components/shared/ui/default-table-btn";
+import {Alert, Button, message, Popconfirm} from "antd";
+import { ColumnsType } from "antd/es/table";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import React, { useCallback, useState } from "react";
+import {deleteEmoji, IEmoji, useEmojis} from "@/client/emoji";
+
+const EmojiList = () => {
+  const [selectedRowKeys, setSelectedRowKeys] = useState<React.Key[]>([]);
+  const [messageApi, contextHolder] = message.useMessage();
+  const router = useRouter();
+
+  const { data, error, isLoading } = useEmojis();
+
+  const handleChangePage = useCallback(
+    (pageNumber: number) => {
+      router.push({
+        pathname: router.pathname,
+        query: { ...router.query, page: pageNumber },
+      });
+    },
+    [router]
+  );
+
+  const onSelectChange = useCallback((newSelectedRowKeys: React.Key[]) => {
+    setSelectedRowKeys(newSelectedRowKeys);
+  }, []);
+
+  const onDelete = (record: IEmoji) => {
+      try{
+          deleteEmoji(record.id)
+          messageApi.success("이모지가 삭제되었습니다.")
+      } catch (e) {
+          messageApi.error("에러가 발생하였습니다.")
+      } finally {
+          router.push("/emoji/list")
+      }
+  }
+
+  const rowSelection = {
+    selectedRowKeys,
+    onChange: onSelectChange,
+  };
+  const hasSelected = selectedRowKeys.length > 0;
+
+  const columns: ColumnsType<IEmoji> = [
+    {
+      key: "action",
+      width: 120,
+      align: "center",
+      render: (_value: unknown, record: IEmoji) => {
+        return (
+          <span className="flex justify-center gap-2">
+            <Link href={`/emoji/edit/${record.id}`} className="px-2 py-1 text-sm btn">
+              수정
+            </Link>
+            <Popconfirm
+              title="이모지를 삭제하시겠습니까?"
+              onConfirm={() => onDelete(record)}
+              okText="예"
+              cancelText="아니오"
+            >
+              <a className="px-2 py-1 text-sm btn">삭제</a>
+            </Popconfirm>
+          </span>
+        );
+      },
+    },
+    {
+      title: "이모지 ID",
+      dataIndex: "id",
+      width: 100,
+        render: (value: string, record: IEmoji) => {
+            return (
+                <span>
+            <span className="px-2 py-1 mr-1 bg-gray-100 rounded">{record.id}</span>
+          </span>
+            );
+        },
+    },
+    {
+      title: "이모지 이름",
+      dataIndex: "name",
+      render: (value: string, record: IEmoji) => {
+        return (
+          <span>
+            <span className="px-2 py-1 mr-1 bg-gray-100 rounded">{record.name}</span>
+          </span>
+        );
+      },
+    },
+    {
+      title: "이모지 URL",
+      dataIndex: "url",
+      render: (value: string, record: IEmoji) => {
+          return (
+              <span>
+                <span className="px-2 py-1 mr-1 bg-gray-100 rounded">{record.url}</span>
+              </span>
+          );
+      },
+    },
+    {
+      title: "이모지 이미지",
+      dataIndex: "name",
+      render: (value: string, record: IEmoji) => {
+          return (
+              <span>
+                <img src={record.url} height={100} width={100} className="px-2 py-1 mr-1 bg-gray-100 rounded" />
+              </span>
+          );
+      },
+    },
+  ];
+
+  if (error) {
+    return <Alert message="데이터 로딩 중 오류가 발생했습니다." type="warning" />;
+  }
+
+  return (
+    <>
+      {contextHolder}
+      <DefaultTableBtn className="justify-between">
+        <div>
+          <span style={{ marginLeft: 8 }}>{hasSelected ? `${selectedRowKeys.length}건 선택` : ""}</span>
+        </div>
+
+        <div className="flex-item-list">
+          <Button type="primary" onClick={() => router.push("/emoji/new")}>
+            이모지 등록
+          </Button>
+        </div>
+      </DefaultTableBtn>
+
+      <DefaultTable<IEmoji>
+        rowSelection={rowSelection}
+        columns={columns}
+        dataSource={data?.body || []}
+        loading={isLoading}
+        pagination={{
+          current: Number(router.query.page || 1),
+          defaultPageSize: 10,
+          total: data?.body.length || 0,
+          showSizeChanger: false,
+          onChange: handleChangePage,
+        }}
+        className="mt-3"
+        countLabel={data?.body.length}
+      />
+    </>
+  );
+};
+
+export default React.memo(EmojiList);

--- a/admin-ui/src/pages/emoji/edit/[id].tsx
+++ b/admin-ui/src/pages/emoji/edit/[id].tsx
@@ -1,0 +1,29 @@
+import { getDefaultLayout, IDefaultLayoutPage, IPageHeader } from "@/components/layout/default-layout";
+import { Alert, Skeleton } from "antd";
+import { useRouter } from "next/router";
+import EmojiForm from "@/components/page/emoji/emoji-form";
+import {useEmoji} from "@/client/emoji";
+
+const pageHeader: IPageHeader = {
+  title: "이모지 수정",
+};
+
+const EmojiEditPage: IDefaultLayoutPage = () => {
+  const router = useRouter();
+  const { data, error, isLoading, isValidating } = useEmoji(router.query.id as string);
+
+  if (error) {
+    return <Alert message="데이터 로딩 중 오류가 발생했습니다." type="warning" className="my-5" />;
+  }
+
+  if (!data || isLoading || isValidating) {
+    return <Skeleton className="my-5" />;
+  }
+
+  return <EmojiForm id={router.query.id as string} initialValues={data.body} />;
+};
+
+EmojiEditPage.getLayout = getDefaultLayout;
+EmojiEditPage.pageHeader = pageHeader;
+
+export default EmojiEditPage;

--- a/admin-ui/src/pages/emoji/list.tsx
+++ b/admin-ui/src/pages/emoji/list.tsx
@@ -1,0 +1,19 @@
+import { getDefaultLayout, IDefaultLayoutPage, IPageHeader } from "@/components/layout/default-layout";
+import EmojiList from "@/components/page/emoji/emoji-list";
+
+const pageHeader: IPageHeader = {
+  title: "이모지 목록",
+};
+
+const EmojiListPage: IDefaultLayoutPage = () => {
+  return (
+    <>
+      <EmojiList />
+    </>
+  );
+};
+
+EmojiListPage.getLayout = getDefaultLayout;
+EmojiListPage.pageHeader = pageHeader;
+
+export default EmojiListPage;

--- a/admin-ui/src/pages/emoji/new.tsx
+++ b/admin-ui/src/pages/emoji/new.tsx
@@ -1,0 +1,15 @@
+import { getDefaultLayout, IDefaultLayoutPage, IPageHeader } from "@/components/layout/default-layout";
+import EmojiForm from "@/components/page/emoji/emoji-form";
+
+const pageHeader: IPageHeader = {
+  title: "이모지 등록",
+};
+
+const EmojiNewPage: IDefaultLayoutPage = () => {
+  return <EmojiForm  />;
+};
+
+EmojiNewPage.getLayout = getDefaultLayout;
+EmojiNewPage.pageHeader = pageHeader;
+
+export default EmojiNewPage;

--- a/backend/application/admin/src/main/kotlin/io/raemian/admin/emoji/EmojiService.kt
+++ b/backend/application/admin/src/main/kotlin/io/raemian/admin/emoji/EmojiService.kt
@@ -1,0 +1,91 @@
+package io.raemian.admin.emoji
+
+import io.raemian.admin.emoji.controller.request.CreateEmojiRequest
+import io.raemian.admin.emoji.controller.request.UpdateEmojiRequest
+import io.raemian.admin.emoji.controller.response.EmojiResponse
+import io.raemian.admin.support.error.CoreApiException
+import io.raemian.admin.support.error.ErrorType
+import io.raemian.image.enums.FileExtensionType
+import io.raemian.image.repository.ImageRepository
+import io.raemian.storage.db.core.emoji.Emoji
+import io.raemian.storage.db.core.emoji.EmojiRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class EmojiService(
+    private val emojiRepository: EmojiRepository,
+    private val imageRepository: ImageRepository,
+) {
+    private val EMOJI_FINAL_PATH = "/emoji"
+
+    @Transactional
+    fun create(
+        createEmojiRequest: CreateEmojiRequest,
+    ): EmojiResponse {
+        val fileName = createEmojiRequest.image.originalFilename
+        validateFileName(fileName)
+
+        val url = imageRepository.upload(
+            finalPath = EMOJI_FINAL_PATH,
+            fileName = fileName!!,
+            inputStream = createEmojiRequest.image.inputStream,
+        )
+
+        val emoji = Emoji(createEmojiRequest.name, url)
+        return EmojiResponse.from(emojiRepository.save(emoji))
+    }
+
+    @Transactional(readOnly = true)
+    fun findAll(): List<EmojiResponse> =
+        emojiRepository.findAll().map(EmojiResponse::from)
+
+    @Transactional(readOnly = true)
+    fun find(emojiId: Long): EmojiResponse =
+        EmojiResponse.from(emojiRepository.getById(emojiId))
+
+    @Transactional
+    fun update(
+        emojiId: Long,
+        updateEmojiRequest: UpdateEmojiRequest,
+    ): EmojiResponse {
+        val newFileName = updateEmojiRequest.image.originalFilename
+        validateFileName(newFileName)
+
+        val emoji = emojiRepository.getById(emojiId)
+        val url = imageRepository.update(
+            finalPath = EMOJI_FINAL_PATH,
+            newFileName = newFileName!!,
+            oldFileName = splitFileNameFromUrl(emoji.url),
+            inputStream = updateEmojiRequest.image.inputStream,
+        )
+
+        emoji.updateNameAndUrl(updateEmojiRequest.name, url)
+        return EmojiResponse.from(emojiRepository.save(emoji))
+    }
+
+    @Transactional
+    fun delete(
+        emojiId: Long,
+    ) {
+        val emoji = emojiRepository.getById(emojiId)
+
+        imageRepository.delete(
+            finalPath = EMOJI_FINAL_PATH,
+            fileName = splitFileNameFromUrl(emoji.url),
+        )
+        emojiRepository.delete(emoji)
+    }
+
+    private fun splitFileNameFromUrl(url: String): String = url.split("/").last()
+
+    private fun validateFileName(fileName: String?) {
+        if (fileName.isNullOrBlank()) {
+            throw CoreApiException(ErrorType.NO_IMAGE_NAME_ERROR)
+        }
+
+        if (!fileName.endsWith(FileExtensionType.PNG.value)) {
+            throw CoreApiException(ErrorType.NO_PNG_FILE_ERROR)
+        }
+    }
+}

--- a/backend/application/admin/src/main/kotlin/io/raemian/admin/emoji/controller/EmojiController.kt
+++ b/backend/application/admin/src/main/kotlin/io/raemian/admin/emoji/controller/EmojiController.kt
@@ -1,0 +1,69 @@
+package io.raemian.admin.emoji.controller
+
+import io.raemian.admin.emoji.EmojiService
+import io.raemian.admin.emoji.controller.request.CreateEmojiRequest
+import io.raemian.admin.emoji.controller.request.UpdateEmojiRequest
+import io.raemian.admin.emoji.controller.response.EmojiResponse
+import io.raemian.admin.support.response.ApiResponse
+import io.swagger.v3.oas.annotations.Operation
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.ModelAttribute
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.net.URI
+
+fun String.toUri(): URI = URI.create(this)
+
+@RestController
+@RequestMapping("/emoji")
+class EmojiController(
+    private val emojiService: EmojiService,
+) {
+
+    @Operation(summary = "이모지 생성 API")
+    @PostMapping(consumes = arrayOf(MediaType.MULTIPART_FORM_DATA_VALUE), produces = arrayOf(MediaType.APPLICATION_JSON_VALUE))
+    fun create(
+        @ModelAttribute createEmojiRequest: CreateEmojiRequest,
+    ): ResponseEntity<ApiResponse<EmojiResponse>> {
+        val response = emojiService.create(createEmojiRequest)
+
+        return ResponseEntity
+            .created("/emoji/${response.id}".toUri())
+            .body(ApiResponse.success(response))
+    }
+
+    @Operation(summary = "이모지 전체 조회 API")
+    @GetMapping
+    fun findAll(): ResponseEntity<ApiResponse<List<EmojiResponse>>> =
+        ResponseEntity.ok(ApiResponse.success(emojiService.findAll()))
+
+    @Operation(summary = "이모지 단건 조회 API")
+    @GetMapping("/{emojiId}")
+    fun find(@PathVariable emojiId: Long): ResponseEntity<ApiResponse<EmojiResponse>> =
+        ResponseEntity.ok(ApiResponse.success(emojiService.find(emojiId)))
+
+    @Operation(summary = "이모지 수정 API")
+    @PatchMapping("/{emojiId}", consumes = arrayOf(MediaType.MULTIPART_FORM_DATA_VALUE), produces = arrayOf(MediaType.APPLICATION_JSON_VALUE))
+    fun update(
+        @PathVariable emojiId: Long,
+        @ModelAttribute updateEmojiRequest: UpdateEmojiRequest,
+    ): ResponseEntity<Unit> {
+        emojiService.update(emojiId, updateEmojiRequest)
+        return ResponseEntity.ok().build()
+    }
+
+    @Operation(summary = "이모지 삭제 API")
+    @DeleteMapping("/{emojiId}")
+    fun delete(
+        @PathVariable emojiId: Long,
+    ): ResponseEntity<Unit> {
+        emojiService.delete(emojiId)
+        return ResponseEntity.noContent().build()
+    }
+}

--- a/backend/application/admin/src/main/kotlin/io/raemian/admin/emoji/controller/request/CreateEmojiRequest.kt
+++ b/backend/application/admin/src/main/kotlin/io/raemian/admin/emoji/controller/request/CreateEmojiRequest.kt
@@ -1,0 +1,9 @@
+package io.raemian.admin.emoji.controller.request
+
+import org.springframework.web.multipart.MultipartFile
+import java.io.Serializable
+
+data class CreateEmojiRequest(
+    val name: String,
+    val image: MultipartFile,
+) : Serializable

--- a/backend/application/admin/src/main/kotlin/io/raemian/admin/emoji/controller/request/UpdateEmojiRequest.kt
+++ b/backend/application/admin/src/main/kotlin/io/raemian/admin/emoji/controller/request/UpdateEmojiRequest.kt
@@ -1,0 +1,8 @@
+package io.raemian.admin.emoji.controller.request
+
+import org.springframework.web.multipart.MultipartFile
+
+data class UpdateEmojiRequest(
+    val name: String,
+    val image: MultipartFile,
+)

--- a/backend/application/admin/src/main/kotlin/io/raemian/admin/emoji/controller/response/EmojiResponse.kt
+++ b/backend/application/admin/src/main/kotlin/io/raemian/admin/emoji/controller/response/EmojiResponse.kt
@@ -1,0 +1,16 @@
+package io.raemian.admin.emoji.controller.response
+
+import io.raemian.storage.db.core.emoji.Emoji
+
+data class EmojiResponse(
+    val id: Long?,
+    val name: String,
+    val url: String,
+) {
+
+    companion object {
+        fun from(emoji: Emoji): EmojiResponse {
+            return EmojiResponse(emoji.id, emoji.name, emoji.url)
+        }
+    }
+}

--- a/backend/application/api/src/main/kotlin/io/raemian/api/emoji/EmojiService.kt
+++ b/backend/application/api/src/main/kotlin/io/raemian/api/emoji/EmojiService.kt
@@ -1,0 +1,60 @@
+package io.raemian.api.emoji
+
+import io.raemian.api.emoji.controller.response.EmojiResponse
+import io.raemian.api.emoji.controller.response.ReactedEmojisResponse
+import io.raemian.storage.db.core.emoji.EmojiRepository
+import io.raemian.storage.db.core.emoji.ReactedEmoji
+import io.raemian.storage.db.core.emoji.ReactedEmojiRepository
+import io.raemian.storage.db.core.goal.GoalRepository
+import io.raemian.storage.db.core.user.UserRepository
+import org.springframework.dao.DataIntegrityViolationException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class EmojiService(
+    private val emojiRepository: EmojiRepository,
+    private val goalRepository: GoalRepository,
+    private val userRepository: UserRepository,
+    private val reactedEmojiRepository: ReactedEmojiRepository,
+) {
+    @Transactional(readOnly = true)
+    fun findAll(): List<EmojiResponse> =
+        emojiRepository.findAll()
+            .map(EmojiResponse::from)
+
+    @Transactional(readOnly = true)
+    fun findGoalReactedEmojis(goalId: Long): ReactedEmojisResponse {
+        val goal = goalRepository.getReferenceById(goalId)
+        val reactedEmojis = reactedEmojiRepository.findAllByGoal(goal)
+        return ReactedEmojisResponse.of(reactedEmojis)
+    }
+
+    @Transactional
+    fun react(emojiId: Long, goalId: Long, emojiReactUserId: Long) {
+        val emoji = emojiRepository.getReferenceById(emojiId)
+        val goal = goalRepository.getReferenceById(goalId)
+        val emojiReactUser = userRepository.getReferenceById(emojiReactUserId)
+        val reactedEmoji = ReactedEmoji(goal, emoji, emojiReactUser)
+
+        ignoreDuplicatedReactedEmojiException {
+            reactedEmojiRepository.save(reactedEmoji)
+        }
+    }
+
+    @Transactional
+    fun remove(emojiId: Long, goalId: Long, emojiReactUserId: Long) {
+        val emoji = emojiRepository.getReferenceById(emojiId)
+        val goal = goalRepository.getReferenceById(goalId)
+        val emojiReactUser = userRepository.getReferenceById(emojiReactUserId)
+
+        reactedEmojiRepository
+            .deleteByEmojiAndGoalAndReactUser(emoji, goal, emojiReactUser)
+    }
+}
+
+inline fun ignoreDuplicatedReactedEmojiException(action: () -> Any) {
+    try {
+        action()
+    } catch (exception: DataIntegrityViolationException) {}
+}

--- a/backend/application/api/src/main/kotlin/io/raemian/api/emoji/EmojiService.kt
+++ b/backend/application/api/src/main/kotlin/io/raemian/api/emoji/EmojiService.kt
@@ -24,7 +24,7 @@ class EmojiService(
             .map(EmojiResponse::from)
 
     @Transactional(readOnly = true)
-    fun findGoalReactedEmojis(goalId: Long): ReactedEmojisResponse {
+    fun findAllReactedEmojisByGoalId(goalId: Long): ReactedEmojisResponse {
         val goal = goalRepository.getReferenceById(goalId)
         val reactedEmojis = reactedEmojiRepository.findAllByGoal(goal)
         return ReactedEmojisResponse.of(reactedEmojis)

--- a/backend/application/api/src/main/kotlin/io/raemian/api/emoji/controller/EmojiController.kt
+++ b/backend/application/api/src/main/kotlin/io/raemian/api/emoji/controller/EmojiController.kt
@@ -1,0 +1,62 @@
+package io.raemian.api.emoji.controller
+
+import io.raemian.api.auth.domain.CurrentUser
+import io.raemian.api.emoji.EmojiService
+import io.raemian.api.emoji.controller.request.ReactEmojiRequest
+import io.raemian.api.emoji.controller.request.RemoveEmojiRequest
+import io.raemian.api.emoji.controller.response.EmojiResponse
+import io.raemian.api.emoji.controller.response.ReactedEmojisResponse
+import io.raemian.api.support.response.ApiResponse
+import io.swagger.v3.oas.annotations.Operation
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/emoji")
+class EmojiController(
+    private val emojiService: EmojiService,
+) {
+
+    @Operation(summary = "이모지 전체 조회 API")
+    @GetMapping
+    fun findAll(): ResponseEntity<ApiResponse<List<EmojiResponse>>> =
+        ResponseEntity.ok(
+            ApiResponse.success(emojiService.findAll()),
+        )
+
+    @Operation(summary = "Goal에 반응된 이모지와 유저 정보 전체 조회 API")
+    @GetMapping("/{goalId}")
+    fun findAllReactedEmojisAtGoal(@PathVariable goalId: Long): ResponseEntity<ApiResponse<ReactedEmojisResponse>> {
+        val response = emojiService.findAllReactedEmojisByGoalId(goalId)
+        return ResponseEntity.ok(ApiResponse.success(response))
+    }
+
+    @Operation(summary = "Goal에 이모지 반응하기 API")
+    @PostMapping("/{goalId}")
+    fun react(
+        @RequestBody reactEmojiRequest: ReactEmojiRequest,
+        @PathVariable goalId: Long,
+        @AuthenticationPrincipal currentUser: CurrentUser,
+    ): ResponseEntity<ApiResponse<Unit>> {
+        emojiService.react(reactEmojiRequest.emojiId, goalId, currentUser.id)
+        return ResponseEntity.ok(ApiResponse.success())
+    }
+
+    @Operation(summary = "Goal에 반응한 이모지 삭제 API")
+    @DeleteMapping("/{goalId}")
+    fun remove(
+        @RequestBody removeEmojiRequest: RemoveEmojiRequest,
+        @PathVariable goalId: Long,
+        @AuthenticationPrincipal currentUser: CurrentUser,
+    ): ResponseEntity<ApiResponse<Unit>> {
+        emojiService.remove(removeEmojiRequest.emojiId, goalId, currentUser.id)
+        return ResponseEntity.ok(ApiResponse.success())
+    }
+}

--- a/backend/application/api/src/main/kotlin/io/raemian/api/emoji/controller/request/ReactEmojiRequest.kt
+++ b/backend/application/api/src/main/kotlin/io/raemian/api/emoji/controller/request/ReactEmojiRequest.kt
@@ -1,0 +1,5 @@
+package io.raemian.api.emoji.controller.request
+
+data class ReactEmojiRequest(
+    val emojiId: Long,
+)

--- a/backend/application/api/src/main/kotlin/io/raemian/api/emoji/controller/request/RemoveEmojiRequest.kt
+++ b/backend/application/api/src/main/kotlin/io/raemian/api/emoji/controller/request/RemoveEmojiRequest.kt
@@ -1,0 +1,5 @@
+package io.raemian.api.emoji.controller.request
+
+data class RemoveEmojiRequest(
+    val emojiId: Long,
+)

--- a/backend/application/api/src/main/kotlin/io/raemian/api/emoji/controller/response/EmojiResponse.kt
+++ b/backend/application/api/src/main/kotlin/io/raemian/api/emoji/controller/response/EmojiResponse.kt
@@ -1,0 +1,16 @@
+package io.raemian.api.emoji.controller.response
+
+import io.raemian.storage.db.core.emoji.Emoji
+
+data class EmojiResponse(
+    val id: Long?,
+    val name: String,
+    val url: String,
+) {
+
+    companion object {
+        fun from(emoji: Emoji): EmojiResponse {
+            return EmojiResponse(emoji.id, emoji.name, emoji.url)
+        }
+    }
+}

--- a/backend/application/api/src/main/kotlin/io/raemian/api/emoji/controller/response/ReactedEmojisResponse.kt
+++ b/backend/application/api/src/main/kotlin/io/raemian/api/emoji/controller/response/ReactedEmojisResponse.kt
@@ -1,0 +1,65 @@
+package io.raemian.api.emoji.controller.response
+
+import io.raemian.storage.db.core.emoji.ReactedEmoji
+import io.raemian.storage.db.core.user.User
+
+data class ReactedEmojisResponse(
+    val totalReactedEmojisCount: Int,
+    val reactedEmojis: Map<Long, ReactedEmojiDTO>,
+) {
+    companion object {
+        fun of(reactedEmojis: List<ReactedEmoji>): ReactedEmojisResponse {
+            val mapValues = reactedEmojis
+                .filter { it.emoji.id != null }
+                .groupBy { it.emoji.id!! }
+                .mapValues(ReactedEmojiDTO.Companion::from)
+
+            val totalEmojisCount = mapValues.values.sumOf { it.count }
+            return ReactedEmojisResponse(totalEmojisCount, mapValues)
+        }
+    }
+
+    data class ReactedEmojiDTO(
+        val id: Long?,
+        val name: String,
+        val url: String,
+        val count: Int,
+        val reactUsers: Set<ReactUserDTO>,
+    ) {
+        companion object {
+            fun from(reactedEmojis2: Map.Entry<Long, List<ReactedEmoji>>): ReactedEmojiDTO {
+                val reactedEmojis = reactedEmojis2.value
+                val emoji = reactedEmojis.first().emoji
+                val reactUsers = getReactUsers(reactedEmojis)
+
+                return ReactedEmojiDTO(
+                    id = emoji.id,
+                    name = emoji.name,
+                    url = emoji.url,
+                    count = reactUsers.size,
+                    reactUsers = reactUsers,
+                )
+            }
+
+            private fun getReactUsers(reactedEmojis: List<ReactedEmoji>) =
+                reactedEmojis.stream()
+                    .map { it.reactUser }
+                    .filter { it.nickname != null }
+                    .map(ReactedEmojisResponse::ReactUserDTO)
+                    .toList()
+                    .toSet()
+        }
+    }
+
+    data class ReactUserDTO(
+        val id: Long,
+        val nickname: String,
+        val image: String,
+    ) {
+        constructor(user: User) : this(
+            id = user.id!!,
+            nickname = user.nickname!!,
+            image = user.image,
+        )
+    }
+}

--- a/backend/application/api/src/test/kotlin/io/raemian/api/integration/emoji/EmojiServiceTest.kt
+++ b/backend/application/api/src/test/kotlin/io/raemian/api/integration/emoji/EmojiServiceTest.kt
@@ -113,7 +113,7 @@ class EmojiServiceTest {
         reactedEmojiRepository.saveAll(listOf(reactedEmoji, reactedEmoji2, reactedEmoji3))
 
         // when
-        val reactedEmojis = emojiService.findGoalReactedEmojis(GOAL_FIXTURE.id!!)
+        val reactedEmojis = emojiService.findAllReactedEmojisByGoalId(GOAL_FIXTURE.id!!)
 
         // then
         assertThat(reactedEmojis.totalReactedEmojisCount).isEqualTo(3)

--- a/backend/application/api/src/test/kotlin/io/raemian/api/integration/emoji/EmojiServiceTest.kt
+++ b/backend/application/api/src/test/kotlin/io/raemian/api/integration/emoji/EmojiServiceTest.kt
@@ -1,0 +1,227 @@
+package io.raemian.api.integration.emoji
+
+import io.raemian.api.emoji.EmojiService
+import io.raemian.storage.db.core.emoji.Emoji
+import io.raemian.storage.db.core.emoji.EmojiRepository
+import io.raemian.storage.db.core.emoji.ReactedEmoji
+import io.raemian.storage.db.core.emoji.ReactedEmojiRepository
+import io.raemian.storage.db.core.goal.Goal
+import io.raemian.storage.db.core.lifemap.LifeMap
+import io.raemian.storage.db.core.sticker.Sticker
+import io.raemian.storage.db.core.tag.Tag
+import io.raemian.storage.db.core.user.Authority
+import io.raemian.storage.db.core.user.User
+import io.raemian.storage.db.core.user.enums.OAuthProvider
+import jakarta.persistence.EntityManager
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+
+@SpringBootTest
+@Transactional
+class EmojiServiceTest {
+
+    companion object {
+        private val USER_FIXTURE = User(
+            email = "dfghcvb111@naver.com",
+            username = "binaryHoHo",
+            nickname = "binaryHoHoHo",
+            birth = LocalDate.MIN,
+            image = "",
+            provider = OAuthProvider.NAVER,
+            authority = Authority.ROLE_USER,
+        )
+
+        private val USER_FIXTURE2 = User(
+            email = "dfghcvb2@naver.com",
+            username = "binaryHo",
+            nickname = "binaryHo",
+            birth = LocalDate.MIN,
+            image = "",
+            provider = OAuthProvider.NAVER,
+            authority = Authority.ROLE_USER,
+        )
+
+        private val LIFE_MAP_FIXTURE = LifeMap(USER_FIXTURE, true)
+        private val STICKER_FIXTURE = Sticker("sticker", "image yeah")
+        private val TAG_FIXTURE = Tag("태그")
+        private val GOAL_FIXTURE = Goal(
+            lifeMap = LIFE_MAP_FIXTURE,
+            title = "제목",
+            deadline = LocalDate.now(),
+            sticker = STICKER_FIXTURE,
+            tag = TAG_FIXTURE,
+            description = "내용",
+        )
+    }
+
+    @Autowired
+    private lateinit var emojiService: EmojiService
+
+    @Autowired
+    private lateinit var emojiRepository: EmojiRepository
+
+    @Autowired
+    private lateinit var reactedEmojiRepository: ReactedEmojiRepository
+
+    @Autowired
+    private lateinit var entityManager: EntityManager
+
+    @BeforeEach
+    fun saveEntities() {
+        entityManager.merge(USER_FIXTURE)
+        entityManager.merge(USER_FIXTURE2)
+        entityManager.merge(LIFE_MAP_FIXTURE)
+        entityManager.merge(STICKER_FIXTURE)
+        entityManager.merge(TAG_FIXTURE)
+        entityManager.merge(GOAL_FIXTURE)
+    }
+
+    @Test
+    @DisplayName("전체 이모지 리스트를 조회할 수 있다.")
+    fun findAllTest() {
+        // given
+        val emoji = Emoji("이모지", "url")
+        val emoji2 = Emoji("이모지2", "url2")
+        emojiRepository.save(emoji)
+        emojiRepository.save(emoji2)
+
+        // when
+        val emojis = emojiService.findAll()
+
+        // then
+        assertThat(emojis.size).isEqualTo(2)
+    }
+
+    @Test
+    @DisplayName("Goal에 달린 이모지들을 조회할 수 있다.")
+    fun findGoalReactedEmojisTest() {
+        // given
+        val emoji = Emoji("이모지", "url")
+        val emoji2 = Emoji("이모지", "url")
+        emojiRepository.saveAll(listOf(emoji, emoji2))
+
+        val reactedEmoji = ReactedEmoji(GOAL_FIXTURE, emoji, USER_FIXTURE)
+        val reactedEmoji2 = ReactedEmoji(GOAL_FIXTURE, emoji, USER_FIXTURE2)
+        val reactedEmoji3 = ReactedEmoji(GOAL_FIXTURE, emoji2, USER_FIXTURE)
+        reactedEmojiRepository.saveAll(listOf(reactedEmoji, reactedEmoji2, reactedEmoji3))
+
+        // when
+        val reactedEmojis = emojiService.findGoalReactedEmojis(GOAL_FIXTURE.id!!)
+
+        // then
+        assertThat(reactedEmojis.totalReactedEmojisCount).isEqualTo(3)
+        println(reactedEmojis)
+    }
+
+    @Test
+    @DisplayName("Goal에 이모지를 반응할 수 있다.")
+    fun reactTest() {
+        // given
+        val emoji = Emoji("이모지", "url")
+        emojiRepository.save(emoji)
+
+        // when
+        emojiService.react(
+            emojiId = emoji.id!!,
+            goalId = GOAL_FIXTURE.id!!,
+            emojiReactUserId = USER_FIXTURE.id!!,
+        )
+
+        // then
+        val reactedEmojis = reactedEmojiRepository.findAllByGoal(GOAL_FIXTURE)
+        assertThat(reactedEmojis.size).isEqualTo(1)
+        assertThat(reactedEmojis.get(0).emoji).isEqualTo(emoji)
+    }
+
+    @Test
+    @DisplayName("하나의 Goal에 같은 유저가 같은 이모지를 여러번 달아도 1개만 저장된다.")
+    fun reactDuplicatedReactTest() {
+        // given
+        val emoji = Emoji("이모지", "url")
+        emojiRepository.save(emoji)
+
+        // when
+        repeat(5) {
+            emojiService.react(
+                emojiId = emoji.id!!,
+                goalId = GOAL_FIXTURE.id!!,
+                emojiReactUserId = USER_FIXTURE.id!!,
+            )
+            entityManager.clear()
+        }
+
+        // then
+        val reactedEmojis = reactedEmojiRepository.findAllByGoal(GOAL_FIXTURE)
+        assertThat(reactedEmojis.size).isEqualTo(1)
+    }
+
+    @Test
+    @DisplayName("하나의 Goal에 같은 유저가 같은 이모지를 여러번 달아도, Entity 중복 예외가 발생되지 않는다.")
+    fun reactDuplicatedReactDoesNotThrowDuplicatedExceptionTest() {
+        // given
+        val emoji = Emoji("이모지", "url")
+        emojiRepository.save(emoji)
+
+        // when
+        val reactEmoji = {
+            emojiService.react(
+                emojiId = emoji.id!!,
+                goalId = GOAL_FIXTURE.id!!,
+                emojiReactUserId = USER_FIXTURE.id!!,
+            )
+            entityManager.clear()
+        }
+
+        // then
+        assertDoesNotThrow {
+            repeat(5) { reactEmoji() }
+        }
+    }
+
+    @Test
+    @DisplayName("반응한 이모지를 삭제할 수 있다.")
+    fun removeTest() {
+        // given
+        val emoji = Emoji("이모지", "url")
+        emojiRepository.save(emoji)
+
+        // when
+        emojiService.remove(
+            emojiId = emoji.id!!,
+            goalId = GOAL_FIXTURE.id!!,
+            emojiReactUserId = USER_FIXTURE.id!!,
+        )
+
+        // then
+        val reactedEmojis = reactedEmojiRepository.findAllByGoal(GOAL_FIXTURE)
+        assertThat(reactedEmojis.size).isEqualTo(0)
+    }
+
+    @Test
+    @DisplayName("반응한 이모지를 여러번 삭제해도 예외가 발생하지 않는다.")
+    fun removeIdempotentTest() {
+        // given
+        val emoji = Emoji("이모지", "url")
+        emojiRepository.save(emoji)
+
+        // when, then
+        assertDoesNotThrow {
+            repeat(5) {
+                emojiService.remove(
+                    emojiId = emoji.id!!,
+                    goalId = GOAL_FIXTURE.id!!,
+                    emojiReactUserId = USER_FIXTURE.id!!,
+                )
+            }
+        }
+        val reactedEmojis = reactedEmojiRepository.findAllByGoal(GOAL_FIXTURE)
+        assertThat(reactedEmojis.size).isEqualTo(0)
+    }
+}

--- a/backend/storage/db-core/src/main/kotlin/io/raemian/storage/db/core/emoji/Emoji.kt
+++ b/backend/storage/db-core/src/main/kotlin/io/raemian/storage/db/core/emoji/Emoji.kt
@@ -1,0 +1,33 @@
+package io.raemian.storage.db.core.emoji
+
+import io.raemian.storage.db.core.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.hibernate.annotations.Nationalized
+
+@Entity
+@Table(name = "EMOJIS")
+class Emoji(
+    @Column(nullable = false)
+    @Nationalized
+    var name: String,
+
+    @Column(nullable = false)
+    var url: String,
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+) : BaseEntity() {
+    fun updateNameAndUrl(
+        name: String,
+        url: String,
+    ) {
+        this.name = name
+        this.url = url
+    }
+}

--- a/backend/storage/db-core/src/main/kotlin/io/raemian/storage/db/core/emoji/EmojiRepository.kt
+++ b/backend/storage/db-core/src/main/kotlin/io/raemian/storage/db/core/emoji/EmojiRepository.kt
@@ -1,0 +1,9 @@
+package io.raemian.storage.db.core.emoji
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface EmojiRepository : JpaRepository<Emoji, Long> {
+
+    override fun getById(id: Long): Emoji =
+        findById(id).orElseThrow { NoSuchElementException("존재하지 않는 눌린 이모지입니다. $id") }
+}

--- a/backend/storage/db-core/src/main/kotlin/io/raemian/storage/db/core/emoji/ReactedEmoji.kt
+++ b/backend/storage/db-core/src/main/kotlin/io/raemian/storage/db/core/emoji/ReactedEmoji.kt
@@ -16,8 +16,8 @@ import jakarta.persistence.UniqueConstraint
 @Table(
     name = "REACTED_EMOJIS",
     uniqueConstraints = [
-        UniqueConstraint(name = "uk_reacted_emoji", columnNames = ["goal_id", "react_user_id", "emoji_id"])
-    ]
+        UniqueConstraint(name = "uk_reacted_emoji", columnNames = ["goal_id", "react_user_id", "emoji_id"]),
+    ],
 )
 class ReactedEmoji(
     @ManyToOne

--- a/backend/storage/db-core/src/main/kotlin/io/raemian/storage/db/core/emoji/ReactedEmoji.kt
+++ b/backend/storage/db-core/src/main/kotlin/io/raemian/storage/db/core/emoji/ReactedEmoji.kt
@@ -1,0 +1,38 @@
+package io.raemian.storage.db.core.emoji
+
+import io.raemian.storage.db.core.BaseEntity
+import io.raemian.storage.db.core.goal.Goal
+import io.raemian.storage.db.core.user.User
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+
+@Entity
+@Table(
+    name = "REACTED_EMOJIS",
+    uniqueConstraints = [
+        UniqueConstraint(name = "uk_reacted_emoji", columnNames = ["goal_id", "react_user_id", "emoji_id"])
+    ]
+)
+class ReactedEmoji(
+    @ManyToOne
+    @JoinColumn(name = "goal_id")
+    val goal: Goal,
+
+    @ManyToOne
+    @JoinColumn(name = "emoji_id")
+    val emoji: Emoji,
+
+    @ManyToOne
+    @JoinColumn(name = "react_user_id")
+    val reactUser: User,
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+) : BaseEntity()

--- a/backend/storage/db-core/src/main/kotlin/io/raemian/storage/db/core/emoji/ReactedEmojiRepository.kt
+++ b/backend/storage/db-core/src/main/kotlin/io/raemian/storage/db/core/emoji/ReactedEmojiRepository.kt
@@ -1,0 +1,12 @@
+package io.raemian.storage.db.core.emoji
+
+import io.raemian.storage.db.core.goal.Goal
+import io.raemian.storage.db.core.user.User
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ReactedEmojiRepository : JpaRepository<ReactedEmoji, Long> {
+
+    fun findAllByGoal(goal: Goal): List<ReactedEmoji>
+
+    fun deleteByEmojiAndGoalAndReactUser(emoji: Emoji, goal: Goal, reactUser: User)
+}


### PR DESCRIPTION
<!--
1. Jira
2. 어떤 작업을 했는지 : 간단하게 설명
3. 자세한 설명 : 필요하다면
4. 영향범위 : 영향받은 모듈
-->

## 📒 Issue
#190 

## 🎯 어떤 작업을 했는지
- 이모지 구현
- Admin 이모지 추가, 수정, 삭제 API와 화면 구현
- 이모지 전체 조회, Goal 이모지 전체 조회 구현
- 이모지 반응, 삭제 구현
- 이모지 반응과 삭제가 동시에 일어날 경우의 대비
- 관련 테스트 코드 작성

## 📜 자세한 설명
반응 관련 -> 처음 부터 비동기로 작성할까 하다가, 단순히 (유저 id, Goal id, Emoji Id) 쌍을 Unique하게 만드는 제약 조건을 걸었습니다. 사실 처음 부터 비동기로 했으면 편했겠지만.. 아직 저희 서비스 이용자가 많지 않아 평범하게 구현해 보았습니다. 동시 요청으로 인한 예외 (이른바 따닥 이슈)를 막기 위해 Unique 조건을 어길 시에도 성공 응답을 내리도록 구현했습니다.

삭제의 경우에도 해당 객체가 존재하지 않아도 아무 일도 일어나지 않습니다.

언급한 특이 케이스들에 대한 테스트 코드를 작성해두었습니다.

Admin 화면은 잘 모르기도 하고.. 파악할 시간이 넉넉하지 않은 것 같아 
우석님 코드 그대로 따라했는데, 빠진 부분 없을지 한번 봐주시겠어요?
아니면 빌드 테스트 해보려면 어떻게 해볼 수 있을까요?

## 🌍 영향범위 (모듈)
application/admin, application/api, storage

---
Resolves: # See also: #
