### PR TITLE
[🛠️ Refactor] Goal Emoji API 응답에 "이모지를 누른 사람 수" 추가

### DIFF
--- a/backend/application/api/src/main/kotlin/io/raemian/api/emoji/controller/response/ReactedEmojisResponse.kt
+++ b/backend/application/api/src/main/kotlin/io/raemian/api/emoji/controller/response/ReactedEmojisResponse.kt
@@ -5,6 +5,7 @@ import io.raemian.storage.db.core.user.User
 
 data class ReactedEmojisResponse(
     val totalReactedEmojisCount: Int,
+    val totalReactUserCount: Int,
     val latestReactUserNickname: String?,
     val reactedEmojis: List<ReactedEmojiAndReactUsers>,
 ) {
@@ -12,10 +13,13 @@ data class ReactedEmojisResponse(
         fun of(reactedEmojis: List<ReactedEmoji>, username: String): ReactedEmojisResponse {
             val reactedEmojiAndReactUsers = convert(reactedEmojis, username)
 
+            val reactedUserCount = countTotalReactUser(reactedEmojiAndReactUsers)
             val totalEmojisCount = reactedEmojiAndReactUsers.sumOf { it.reactCount }
+
             val latestReactUserNickname = reactedEmojis.lastOrNull()?.reactUser?.nickname
             return ReactedEmojisResponse(
                 totalReactedEmojisCount = totalEmojisCount,
+                totalReactUserCount = reactedUserCount,
                 latestReactUserNickname = latestReactUserNickname,
                 reactedEmojis = reactedEmojiAndReactUsers,
             )
@@ -31,6 +35,13 @@ data class ReactedEmojisResponse(
                 .mapValues { entry -> ReactedEmojiAndReactUsers.of(entry.value, username) }
                 .values
                 .toList()
+
+        private fun countTotalReactUser(reactedEmojiAndReactUsers: List<ReactedEmojiAndReactUsers>) =
+            reactedEmojiAndReactUsers
+                .flatMap { it.reactUsers }
+                .map { it.username }
+                .distinct()
+                .size
     }
 
     data class ReactedEmojiAndReactUsers(

--- a/backend/application/api/src/test/kotlin/io/raemian/api/integration/emoji/EmojiServiceTest.kt
+++ b/backend/application/api/src/test/kotlin/io/raemian/api/integration/emoji/EmojiServiceTest.kt
@@ -226,4 +226,37 @@ class EmojiServiceTest {
         val reactedEmojis = reactedEmojiRepository.findAllByGoal(GOAL_FIXTURE)
         assertThat(reactedEmojis.size).isEqualTo(0)
     }
+
+    @Test
+    @DisplayName("Goal에 반응한 사람 수를 확인할 수 있다.")
+    fun totalReactUserCountTest() {
+        // given
+        val userFixture3 = User(
+            email = "dfghcvb2",
+            username = "binary",
+            nickname = "binary",
+            birth = LocalDate.MIN,
+            image = "",
+            provider = OAuthProvider.NAVER,
+            authority = Authority.ROLE_USER,
+        )
+        entityManager.merge(userFixture3)
+
+        val emoji = Emoji("이모지", "url")
+        val emoji2 = Emoji("이모지", "url")
+        emojiRepository.saveAll(listOf(emoji, emoji2))
+
+        val reactedEmoji = ReactedEmoji(GOAL_FIXTURE, emoji, USER_FIXTURE)
+        val reactedEmoji2 = ReactedEmoji(GOAL_FIXTURE, emoji, USER_FIXTURE2)
+        val reactedEmoji3 = ReactedEmoji(GOAL_FIXTURE, emoji2, USER_FIXTURE)
+        val reactedEmoji4 = ReactedEmoji(GOAL_FIXTURE, emoji2, USER_FIXTURE2)
+        val reactedEmoji5 = ReactedEmoji(GOAL_FIXTURE, emoji2, userFixture3)
+        reactedEmojiRepository.saveAll(listOf(reactedEmoji, reactedEmoji2, reactedEmoji3, reactedEmoji4, reactedEmoji5))
+
+        // when
+        val reactedEmojis = emojiService.findAllReactedEmojisByGoalId(GOAL_FIXTURE.id!!, USER_FIXTURE.username!!)
+
+        // then
+        assertThat(reactedEmojis.totalReactUserCount).isEqualTo(3)
+    }
 }


### PR DESCRIPTION
<!--
1. Jira
2. 어떤 작업을 했는지 : 간단하게 설명
3. 자세한 설명 : 필요하다면
4. 영향범위 : 영향받은 모듈
-->

## 📒 Issue
#218 

## 🎯 어떤 작업을 했는지
Goal Emoji API 응답에 "이모지를 누른 사람 수" 추가
최종적으로 표시되는 인원들의 username을 기준으로 스트림을 통해 유니크하게 세었다.
(null은 세기 전에 걸러진다)

---
Resolves: # See also: #
