### PR TITLE
[🛠️ Refactor] 댓글 응답에 댓글 갯수 추가 

### DIFF
--- a/backend/application/api/src/main/kotlin/io/raemian/api/comment/controller/response/CommentsResponse.kt
+++ b/backend/application/api/src/main/kotlin/io/raemian/api/comment/controller/response/CommentsResponse.kt
@@ -4,13 +4,16 @@ import io.raemian.storage.db.core.comment.Comment
 import io.raemian.storage.db.core.user.User
 import java.time.LocalDateTime
 
-data class CommentsResponse(val comments: List<CommentResponse>) {
+data class CommentsResponse(
+    val comments: List<CommentResponse>,
+    val commentCount: Int,
+) {
     companion object {
         fun from(comments: List<Comment>, userId: Long): CommentsResponse {
             val comments = comments
                 .map { CommentResponse.from(it, userId) }
                 .sortedBy { it.writtenAt }
-            return CommentsResponse(comments)
+            return CommentsResponse(comments, comments.size)
         }
     }
 

--- a/backend/application/api/src/test/kotlin/io/raemian/api/integration/comment/CommentServiceTest.kt
+++ b/backend/application/api/src/test/kotlin/io/raemian/api/integration/comment/CommentServiceTest.kt
@@ -96,6 +96,21 @@ class CommentServiceTest {
     }
 
     @Test
+    @DisplayName("Goal의 Comment들을 조회할 때, 갯수를 함께 받을 수 있다.")
+    fun getAllByGoalIdCommentCountTest() {
+        // given
+        commentRepository.save(Comment(GOAL_FIXTURE, USER_FIXTURE, "comment0"))
+        commentRepository.save(Comment(GOAL_FIXTURE, USER_FIXTURE, "comment1"))
+        commentRepository.save(Comment(GOAL_FIXTURE, USER_FIXTURE, "comment2"))
+
+        // when
+        val comments = commentService.findAllByGoalId(GOAL_FIXTURE.id!!, USER_FIXTURE.id!!)
+
+        // then
+        assertThat(comments.commentCount).isEqualTo(3);
+    }
+
+    @Test
     @DisplayName("유저는 읽지 않은 Comment가 있는지 확인할 수 있다.")
     fun isNewTest() {
         // given


### PR DESCRIPTION
<!--
1. Jira
2. 어떤 작업을 했는지 : 간단하게 설명
3. 자세한 설명 : 필요하다면
4. 영향범위 : 영향받은 모듈
-->

## 📒 Issue
#224 

## 🎯 어떤 작업을 했는지
1. 댓글 응답에 댓글 전체 갯수를 추가
2. 테스트 코드 작성

## Before
```json
"comments": [
      {
        "id": 0,
        "content": "string",
        "writtenAt": "2024-03-14T04:01:22.339Z",
        "commenter": {
          "username": "string",
          "nickname": "string",
          "image": "string"
        },
        "isMyComment": true
      }
    ]
```
## After
```json
"comments": [
      {
        "id": 0,
        "content": "string",
        "writtenAt": "2024-03-14T04:01:22.339Z",
        "commenter": {
          "username": "string",
          "nickname": "string",
          "image": "string"
        },
        "isMyComment": true
      }
    ],
"commentCount": 1    // 추가
```
