### PR TITLE
[🛠️ Refactor] 댓글 조회 API 응답에 "내 지도 확인" key-value 추가

### DIFF
--- a/backend/application/api/src/main/kotlin/io/raemian/api/comment/controller/response/CommentsResponse.kt
+++ b/backend/application/api/src/main/kotlin/io/raemian/api/comment/controller/response/CommentsResponse.kt
@@ -7,13 +7,14 @@ import java.time.LocalDateTime
 data class CommentsResponse(
     val comments: List<CommentResponse>,
     val commentCount: Int,
+    val isMyGoal: Boolean,
 ) {
     companion object {
-        fun from(comments: List<Comment>, userId: Long): CommentsResponse {
+        fun from(comments: List<Comment>, userId: Long, isMyGoal: Boolean): CommentsResponse {
             val comments = comments
                 .map { CommentResponse.from(it, userId) }
                 .sortedBy { it.writtenAt }
-            return CommentsResponse(comments, comments.size)
+            return CommentsResponse(comments, comments.size, isMyGoal)
         }
     }
 

--- a/backend/application/api/src/test/kotlin/io/raemian/api/integration/comment/CommentServiceTest.kt
+++ b/backend/application/api/src/test/kotlin/io/raemian/api/integration/comment/CommentServiceTest.kt
@@ -111,6 +111,22 @@ class CommentServiceTest {
     }
 
     @Test
+    @DisplayName("Goal의 Comment 조회시, 나의 Goal인지 확인할 수 있다.")
+    fun getAllByGoalIdIsMyGoalTest() {
+        // given
+        commentRepository.save(Comment(GOAL_FIXTURE, USER_FIXTURE, "comment0"))
+
+        // when
+        val comments = commentService.findAllByGoalId(GOAL_FIXTURE.id!!, USER_FIXTURE.id!!)
+        val anotherUserId = USER_FIXTURE.id!! + 1
+        val comments2 = commentService.findAllByGoalId(GOAL_FIXTURE.id!!, anotherUserId)
+
+        // then
+        assertThat(comments.isMyGoal).isEqualTo(true)
+        assertThat(comments2.isMyGoal).isEqualTo(false)
+    }
+
+    @Test
     @DisplayName("유저는 읽지 않은 Comment가 있는지 확인할 수 있다.")
     fun isNewTest() {
         // given


### PR DESCRIPTION
<!--
1. Jira
2. 어떤 작업을 했는지 : 간단하게 설명
3. 자세한 설명 : 필요하다면
4. 영향범위 : 영향받은 모듈
-->

## 📒 Issue
#229 

## 🎯 어떤 작업을 했는지
댓글 조회 API 응답에 "내 지도 확인" key가 필요하다는 요청이 있었다.
인생 지도의 Goal에서 댓글 조회로 넘어가는 경우, 이미 Goal 페이지에서 isMyGoal state를 받아 클라에서 가지고 있지만,
피드에서 바로 넘어가는 경우, 해당 값을 갖고 있지 않아 내 지도인지 확인하기가 어렵다.

<br>

내 지도인지 확인할 수 있어야 댓글 삭제 버튼을 보여줄 수 있다.
이에 댓글 조회 API 응답에 "내 지도 확인" key를 추가한다.

## 작업 내용
1. CommentsResponse에 isMyGoal 필드 추가
comments를 가져올 때, 내부적으로 Goal정보를 가지고 있습니다. 이를 통해 자신의 Goal인지 확인한다. comments가 비어있는 경우 goal db에서 데이터를 가져와서 조회한다. (isMyGoal 메서드)

2. 테스트 코드 추가
