### PR TITLE
[🚌 Issue] 브랜치 룰 적용 확인을 위한 항상 실패하는 테스트 코드 작성

### DIFF
--- a/backend/application/api/src/test/kotlin/io/raemian/api/FailTest.kt
+++ b/backend/application/api/src/test/kotlin/io/raemian/api/FailTest.kt
@@ -1,0 +1,14 @@
+package io.raemian.api
+
+import org.junit.jupiter.api.Assertions.fail
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+
+@SpringBootTest
+class FailTest {
+
+    @Test
+    fun MergeRule_적용_확인을_위한_항상_실패하는_테스트() {
+        fail()
+    }
+}


### PR DESCRIPTION
## 📒 Issue
#239

## 🎯 어떤 작업을 했는지
자동 Merge 도입을 위한 룰 설정 중 상태 검사를 실패하기 위해, 
항상 실패하는 테스트 코드를 작성했다.