### PR TITLE
[🛠️ Refactor] 타임 라인 API 작업 리팩토링

### DIFF
--- a/backend/application/api/src/main/kotlin/io/raemian/api/cheer/service/CheeringService.kt
+++ b/backend/application/api/src/main/kotlin/io/raemian/api/cheer/service/CheeringService.kt
@@ -52,7 +52,7 @@ class CheeringService(
 
         val cheeringSquad = findCheeringSquadWithCursor(lifeMapId, request)
 
-        val filteredCheeringSquad = cheeringSquad.transform(CheererResult::from)
+        val filteredCheeringSquad = cheeringSquad.transform { CheererResult.from(it) }
 
         return PaginationResult.from(cheering.count, filteredCheeringSquad)
     }

--- a/backend/application/api/src/main/kotlin/io/raemian/api/goal/service/GoalQueryService.kt
+++ b/backend/application/api/src/main/kotlin/io/raemian/api/goal/service/GoalQueryService.kt
@@ -35,7 +35,7 @@ class GoalQueryService(
 
         return PaginationResult.from(
             lifeMap.goals.size.toLong(),
-            goals.transform() {
+            goals.transform {
                     goal ->
                 GoalTimelinePageResult.from(
                     goal,

--- a/backend/application/api/src/main/kotlin/io/raemian/api/goal/service/GoalQueryService.kt
+++ b/backend/application/api/src/main/kotlin/io/raemian/api/goal/service/GoalQueryService.kt
@@ -30,7 +30,7 @@ class GoalQueryService(
 
         val goalIds = goals.contents.map { it.goalId }
 
-        val goalTimelineCountMap = findGoalTimelineCountMap(goalIds)
+        val goalCountMap = findGoalCountMap(goalIds)
         val reactedEmojiMap = emojiService.findAllByGoalIds(goalIds, lifeMap.user.id)
 
         return PaginationResult.from(
@@ -38,14 +38,14 @@ class GoalQueryService(
             goals.transform {
                 GoalTimelinePageResult.from(
                     goal = it,
-                    counts = goalTimelineCountMap[it.goalId],
+                    counts = goalCountMap[it.goalId],
                     reactedEmojisResult = reactedEmojiMap[it.goalId],
                 )
             },
         )
     }
 
-    private fun findGoalTimelineCountMap(goalIds: List<Long>): Map<Long, GoalTimelineCountSubset> {
+    private fun findGoalCountMap(goalIds: List<Long>): Map<Long, GoalTimelineCountSubset> {
         val commentCountMap = commentService.findGoalCommentCounts(goalIds).associate { it.goalId to it.commentCount }
         val taskCountMap = taskService.findGoalTaskCounts(goalIds).associate { it.goalId to it.taskCount }
 

--- a/backend/application/api/src/main/kotlin/io/raemian/api/goal/service/GoalQueryService.kt
+++ b/backend/application/api/src/main/kotlin/io/raemian/api/goal/service/GoalQueryService.kt
@@ -24,30 +24,6 @@ class GoalQueryService(
     private val commentService: CommentService,
 ) {
     @Transactional(readOnly = true)
-    fun findAllByUserIdWithCursor(userId: Long, request: TimelinePageRequest): PaginationResult<GoalTimelinePageResult> {
-        val lifeMap = lifeMapService.findFirstByUserId(userId)
-
-        val goals = findAllByLifeMapIdWithCursor(lifeMap.lifeMapId, request)
-
-        val goalIds = goals.contents.map { it.goalId }
-
-        val goalTimelineCountMap = findGoalTimelineCountMap(goalIds)
-        val reactedEmojiMap = emojiService.findAllByGoalIds(goalIds, userId)
-
-        return PaginationResult.from(
-            lifeMap.goals.size.toLong(),
-            goals.transform() {
-                    goal ->
-                GoalTimelinePageResult.from(
-                    goal,
-                    goalTimelineCountMap[goal.goalId],
-                    reactedEmojiMap[goal.goalId],
-                )
-            },
-        )
-    }
-
-    @Transactional(readOnly = true)
     fun findAllByUsernameWithCursor(username: String, request: TimelinePageRequest): PaginationResult<GoalTimelinePageResult> {
         val lifeMap = lifeMapService.findFirstByUserName(username)
         val goals = findAllByLifeMapIdWithCursor(lifeMap.lifeMapId, request)

--- a/backend/application/api/src/main/kotlin/io/raemian/api/goal/service/GoalQueryService.kt
+++ b/backend/application/api/src/main/kotlin/io/raemian/api/goal/service/GoalQueryService.kt
@@ -25,7 +25,7 @@ class GoalQueryService(
 ) {
     @Transactional(readOnly = true)
     fun findAllByUsernameWithCursor(username: String, request: TimelinePageRequest): PaginationResult<GoalTimelinePageResult> {
-        val lifeMap = lifeMapService.findFirstByUserName(username)
+        val lifeMap = lifeMapService.getFirstByUserName(username)
         val goals = findAllByLifeMapIdWithCursor(lifeMap.lifeMapId, request)
 
         val goalIds = goals.contents.map { it.goalId }
@@ -34,7 +34,7 @@ class GoalQueryService(
         val reactedEmojiMap = emojiService.findAllByGoalIds(goalIds, lifeMap.user.id)
 
         return PaginationResult.from(
-            lifeMap.goals.size.toLong(),
+            lifeMap.goals.size,
             goals.transform {
                     goal ->
                 GoalTimelinePageResult.from(

--- a/backend/application/api/src/main/kotlin/io/raemian/api/goal/service/GoalQueryService.kt
+++ b/backend/application/api/src/main/kotlin/io/raemian/api/goal/service/GoalQueryService.kt
@@ -36,11 +36,10 @@ class GoalQueryService(
         return PaginationResult.from(
             lifeMap.goals.size,
             goals.transform {
-                    goal ->
                 GoalTimelinePageResult.from(
-                    goal,
-                    goalTimelineCountMap[goal.goalId],
-                    reactedEmojiMap[goal.goalId],
+                    goal = it,
+                    counts = goalTimelineCountMap[it.goalId],
+                    reactedEmojisResult = reactedEmojiMap[it.goalId],
                 )
             },
         )

--- a/backend/application/api/src/main/kotlin/io/raemian/api/goal/service/GoalQueryService.kt
+++ b/backend/application/api/src/main/kotlin/io/raemian/api/goal/service/GoalQueryService.kt
@@ -49,8 +49,8 @@ class GoalQueryService(
         val commentCountMap = commentService.findGoalCommentCounts(goalIds).associate { it.goalId to it.commentCount }
         val taskCountMap = taskService.findGoalTaskCounts(goalIds).associate { it.goalId to it.taskCount }
 
-        return goalIds.associate {
-            it to GoalTimelineCountSubset.of(
+        return goalIds.associateWith {
+            GoalTimelineCountSubset.of(
                 commentCountMap[it] ?: 0,
                 taskCountMap[it] ?: 0,
             )

--- a/backend/application/api/src/main/kotlin/io/raemian/api/lifemap/controller/LifeMapController.kt
+++ b/backend/application/api/src/main/kotlin/io/raemian/api/lifemap/controller/LifeMapController.kt
@@ -40,16 +40,6 @@ class LifeMapController(
             .ok(ApiResponse.success(LifeMapResponse(lifeMap, count, cheeringCount)))
     }
 
-    @Operation(summary = "로그인한 유저의 인생 지도 타임 라인 조회 API")
-    @GetMapping("/timeline")
-    fun getTimeline(
-        @AuthenticationPrincipal currentUser: CurrentUser,
-        request: TimelinePageRequest,
-    ): ResponseEntity<ApiResponse<PaginationResult<GoalTimelinePageResult>>> {
-        val goalTimeline = goalQueryService.findAllByUserIdWithCursor(currentUser.id, request)
-        return ResponseEntity.ok(ApiResponse.success(goalTimeline))
-    }
-
     @Operation(summary = "인생 지도 공개 여부를 수정하는 API")
     @PatchMapping("/publication")
     fun updatePublic(

--- a/backend/application/api/src/main/kotlin/io/raemian/api/lifemap/controller/LifeMapController.kt
+++ b/backend/application/api/src/main/kotlin/io/raemian/api/lifemap/controller/LifeMapController.kt
@@ -2,14 +2,11 @@ package io.raemian.api.lifemap.controller
 
 import io.raemian.api.auth.model.CurrentUser
 import io.raemian.api.cheer.service.CheeringService
-import io.raemian.api.goal.controller.request.TimelinePageRequest
-import io.raemian.api.goal.model.GoalTimelinePageResult
 import io.raemian.api.goal.service.GoalQueryService
 import io.raemian.api.lifemap.controller.request.UpdatePublicRequest
 import io.raemian.api.lifemap.model.LifeMapResponse
 import io.raemian.api.lifemap.service.LifeMapService
 import io.raemian.api.support.response.ApiResponse
-import io.raemian.api.support.response.PaginationResult
 import io.swagger.v3.oas.annotations.Operation
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
@@ -32,7 +29,7 @@ class LifeMapController(
     fun findAllByCurrentUser(
         @AuthenticationPrincipal currentUser: CurrentUser,
     ): ResponseEntity<ApiResponse<LifeMapResponse>> {
-        val lifeMap = lifeMapService.findFirstByUserId(currentUser.id)
+        val lifeMap = lifeMapService.getFirstByUserId(currentUser.id)
         val count = lifeMapService.getLifeMapCount(lifeMap.lifeMapId)
         val cheeringCount = cheeringService.getCheeringCount(currentUser.id)
 

--- a/backend/application/api/src/main/kotlin/io/raemian/api/lifemap/controller/OpenLifeMapController.kt
+++ b/backend/application/api/src/main/kotlin/io/raemian/api/lifemap/controller/OpenLifeMapController.kt
@@ -31,7 +31,7 @@ class OpenLifeMapController(
         @AuthenticationPrincipal currentUser: CurrentUser?,
         @PathVariable("username") username: String,
     ): ResponseEntity<ApiResponse<LifeMapResponse>> {
-        val lifeMap = lifeMapService.findFirstByUserName(username)
+        val lifeMap = lifeMapService.getFirstByUserName(username)
         val count = lifeMapService.addViewCount(lifeMap.lifeMapId)
         val cheeringCount = cheeringService.getCheeringCount(username)
 

--- a/backend/application/api/src/main/kotlin/io/raemian/api/lifemap/service/LifeMapService.kt
+++ b/backend/application/api/src/main/kotlin/io/raemian/api/lifemap/service/LifeMapService.kt
@@ -23,7 +23,7 @@ class LifeMapService(
     private val lifeMapHistoryRepository: LifeMapHistoryRepository,
 ) {
     @Transactional(readOnly = true)
-    fun findFirstByUserId(userId: Long): LifeMapResult {
+    fun getFirstByUserId(userId: Long): LifeMapResult {
         val lifeMap = lifeMapRepository.findFirstByUserId(userId)
             ?: throw NoSuchElementException("존재하지 않는 유저입니다. $userId")
 
@@ -34,7 +34,7 @@ class LifeMapService(
     }
 
     @Transactional(readOnly = true)
-    fun findFirstByUserName(username: String): LifeMapResult {
+    fun getFirstByUserName(username: String): LifeMapResult {
         val lifeMap = lifeMapRepository.findFirstByUserUsername(username)
             ?: throw NoSuchElementException("존재하지 않는 유저입니다. $username")
 

--- a/backend/application/api/src/main/kotlin/io/raemian/api/support/response/PaginationResult.kt
+++ b/backend/application/api/src/main/kotlin/io/raemian/api/support/response/PaginationResult.kt
@@ -3,15 +3,24 @@ package io.raemian.api.support.response
 import io.raemian.storage.db.core.common.pagination.CursorPaginationResult
 
 data class PaginationResult<T>(
-    val total: Int,
+    val total: Long,
     val contents: List<T>,
     val isLast: Boolean,
     val nextCursor: Long?,
 ) {
     companion object {
-        fun <T> from(total: Int, result: CursorPaginationResult<T>): PaginationResult<T> {
+        fun <T> from(total: Long, result: CursorPaginationResult<T>): PaginationResult<T> {
             return PaginationResult(
                 total = total,
+                contents = result.contents,
+                isLast = result.isLast,
+                nextCursor = result.nextCursor,
+            )
+        }
+
+        fun <T> from(total: Int, result: CursorPaginationResult<T>): PaginationResult<T> {
+            return PaginationResult(
+                total = total.toLong(),
                 contents = result.contents,
                 isLast = result.isLast,
                 nextCursor = result.nextCursor,

--- a/backend/application/api/src/main/kotlin/io/raemian/api/support/response/PaginationResult.kt
+++ b/backend/application/api/src/main/kotlin/io/raemian/api/support/response/PaginationResult.kt
@@ -3,13 +3,13 @@ package io.raemian.api.support.response
 import io.raemian.storage.db.core.common.pagination.CursorPaginationResult
 
 data class PaginationResult<T>(
-    val total: Long,
+    val total: Int,
     val contents: List<T>,
     val isLast: Boolean,
     val nextCursor: Long?,
 ) {
     companion object {
-        fun <T> from(total: Long, result: CursorPaginationResult<T>): PaginationResult<T> {
+        fun <T> from(total: Int, result: CursorPaginationResult<T>): PaginationResult<T> {
             return PaginationResult(
                 total = total,
                 contents = result.contents,

--- a/backend/application/api/src/main/kotlin/io/raemian/api/user/controller/UserController.kt
+++ b/backend/application/api/src/main/kotlin/io/raemian/api/user/controller/UserController.kt
@@ -27,7 +27,7 @@ class UserController(
     @GetMapping("/my")
     fun my(@AuthenticationPrincipal currentUser: CurrentUser): ResponseEntity<ApiResponse<UserTokenDecryptResult>> {
         val user = userService.getUserById(currentUser.id)
-        val lifeMap = lifeMapService.findFirstByUserId(currentUser.id)
+        val lifeMap = lifeMapService.getFirstByUserId(currentUser.id)
         val response = UserTokenDecryptResult.of(user, lifeMap)
         return ResponseEntity.ok(ApiResponse.success(response))
     }

--- a/backend/application/api/src/test/kotlin/io/raemian/api/integration/lifemap/LifeMapServiceTest.kt
+++ b/backend/application/api/src/test/kotlin/io/raemian/api/integration/lifemap/LifeMapServiceTest.kt
@@ -92,7 +92,7 @@ class LifeMapServiceTest {
         lifeMap.addGoal(goal2)
 
         // when
-        val savedLifeMap = lifeMapService.findFirstByUserId(USER_FIXTURE.id!!)
+        val savedLifeMap = lifeMapService.getFirstByUserId(USER_FIXTURE.id!!)
 
         // then
         assertAll(
@@ -134,7 +134,7 @@ class LifeMapServiceTest {
         lifeMap.addGoal(goal2)
 
         // when
-        val savedLifeMap = lifeMapService.findFirstByUserId(USER_FIXTURE.id!!)
+        val savedLifeMap = lifeMapService.getFirstByUserId(USER_FIXTURE.id!!)
 
         // then
         assertAll(
@@ -157,7 +157,7 @@ class LifeMapServiceTest {
         // when
         // then
         assertThatThrownBy {
-            lifeMapService.findFirstByUserName(USER_FIXTURE.username!!)
+            lifeMapService.getFirstByUserName(USER_FIXTURE.username!!)
         }.isInstanceOf(RuntimeException::class.java)
     }
 
@@ -192,7 +192,7 @@ class LifeMapServiceTest {
         lifeMap.addGoal(goal2)
 
         // when
-        val savedLifeMap = lifeMapService.findFirstByUserId(USER_FIXTURE.id!!)
+        val savedLifeMap = lifeMapService.getFirstByUserId(USER_FIXTURE.id!!)
 
         // then
         var month = (now.monthValue).toString()

--- a/backend/storage/db-core/src/main/kotlin/io/raemian/storage/db/core/common/pagination/CursorPaginationTemplate.kt
+++ b/backend/storage/db-core/src/main/kotlin/io/raemian/storage/db/core/common/pagination/CursorPaginationTemplate.kt
@@ -9,7 +9,7 @@ object CursorPaginationTemplate {
         size: Int,
         query: TriFunction<Long, Long, Int, List<T>>,
     ): CursorPaginationResult<T> {
-        val data = query.apply(id, cursorId ?: 0, size + 1)
+        val data = query.apply(id, cursorId, size + 1)
         val isLast = data.size != size + 1
         val nextCursor = if (isLast) null else data[size].getCursorId()
 


### PR DESCRIPTION
<!--
1. Jira
2. 어떤 작업을 했는지 : 간단하게 설명
3. 자세한 설명 : 필요하다면
4. 영향범위 : 영향받은 모듈
-->

## 📒 Issue
#235 

## 🎯 어떤 작업을 했는지
- 로그인 정보를 활용한 타임라인 조회 API 제거
    - 타인의 타임라인도 조회가 가능해야 하기에 username기반의 조회 API 1개만 필요
- 로직의 반환값이 empty case를 고려하는지에 따라 메서드 명 find/get 분리 적용
- 위 2가지가 큰 변화이고 나머지는 자잘한 네이밍 수정이나 메서드 사용 방식 변경입니다.


## 🌍 영향범위 (모듈)
- application/api

---
Resolves: # See also: #
