### PR TITLE
[🛠️ Refactor] 댓글, 이모지의 Goal 삭제 Casacde 설정

### DIFF
--- a/backend/storage/db-core/src/main/kotlin/io/raemian/storage/db/core/comment/Comment.kt
+++ b/backend/storage/db-core/src/main/kotlin/io/raemian/storage/db/core/comment/Comment.kt
@@ -12,12 +12,15 @@ import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 import org.hibernate.annotations.Nationalized
+import org.hibernate.annotations.OnDelete
+import org.hibernate.annotations.OnDeleteAction
 
 @Entity
 @Table(name = "COMMENTS")
 class Comment(
     @ManyToOne
     @JoinColumn(name = "goal_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     val goal: Goal,
 
     @ManyToOne

--- a/backend/storage/db-core/src/main/kotlin/io/raemian/storage/db/core/emoji/ReactedEmoji.kt
+++ b/backend/storage/db-core/src/main/kotlin/io/raemian/storage/db/core/emoji/ReactedEmoji.kt
@@ -11,6 +11,8 @@ import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 import jakarta.persistence.UniqueConstraint
+import org.hibernate.annotations.OnDelete
+import org.hibernate.annotations.OnDeleteAction
 
 @Entity
 @Table(
@@ -22,6 +24,7 @@ import jakarta.persistence.UniqueConstraint
 class ReactedEmoji(
     @ManyToOne
     @JoinColumn(name = "goal_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     val goal: Goal,
 
     @ManyToOne


### PR DESCRIPTION
<!--
1. Jira
2. 어떤 작업을 했는지 : 간단하게 설명
3. 자세한 설명 : 필요하다면
4. 영향범위 : 영향받은 모듈
-->

## 📒 Issue

## 🎯 어떤 작업을 했는지
댓글, 이모지의 Goal 삭제 Casacde 설정을 빠트려 제대로 Goal이 삭제되지 않음을 확인했다.
그래서 Goal이 삭제되는 경우, 댓글과 이모지가 삭제되도록 @onDelete를 추가한다.

