### PR TITLE
[🛠️ Refactor] 이모지 반응 전 존재 여부 확인 추가 (#253)

### DIFF
--- a/backend/application/api/src/main/kotlin/io/raemian/api/emoji/service/EmojiService.kt
+++ b/backend/application/api/src/main/kotlin/io/raemian/api/emoji/service/EmojiService.kt
@@ -4,14 +4,12 @@ import io.raemian.api.emoji.model.EmojiResult
 import io.raemian.api.emoji.model.ReactedEmojisResult
 import io.raemian.api.event.model.ReactedEmojiEvent
 import io.raemian.api.event.model.RemovedEmojiEvent
-import io.raemian.storage.db.core.emoji.EmojiCountRepository
 import io.raemian.storage.db.core.emoji.EmojiRepository
 import io.raemian.storage.db.core.emoji.ReactedEmoji
 import io.raemian.storage.db.core.emoji.ReactedEmojiRepository
 import io.raemian.storage.db.core.goal.GoalRepository
 import io.raemian.storage.db.core.user.UserRepository
 import org.springframework.context.ApplicationEventPublisher
-import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -22,7 +20,6 @@ class EmojiService(
     private val userRepository: UserRepository,
     private val reactedEmojiRepository: ReactedEmojiRepository,
     private val applicationEventPublisher: ApplicationEventPublisher,
-    private val emojiCountRepository: EmojiCountRepository,
 ) {
     @Transactional(readOnly = true)
     fun findAll(): List<EmojiResult> =
@@ -41,14 +38,25 @@ class EmojiService(
         val emoji = emojiRepository.getReferenceById(emojiId)
         val goal = goalRepository.getReferenceById(goalId)
         val emojiReactUser = userRepository.getReferenceById(emojiReactUserId)
-        val reactedEmoji = ReactedEmoji(goal, emoji, emojiReactUser)
 
-        ignoreDuplicatedReactedEmojiException {
+        if (isReactedEmojiNotExist(
+                reactUserId = emojiReactUserId,
+                goalId = goalId,
+                emojiId = emojiId,
+            )
+        ) {
+            val reactedEmoji = ReactedEmoji(goal, emoji, emojiReactUser)
             reactedEmojiRepository.save(reactedEmoji)
+            applicationEventPublisher.publishEvent(ReactedEmojiEvent(goalId, emojiId))
         }
-
-        applicationEventPublisher.publishEvent(ReactedEmojiEvent(goalId, emojiId))
     }
+
+    private fun isReactedEmojiNotExist(reactUserId: Long, goalId: Long, emojiId: Long) =
+        reactedEmojiRepository.existsByReactUserIdAndGoalIdAndEmojiId(
+            reactUserId = reactUserId,
+            goalId = goalId,
+            emojiId = emojiId,
+        ).not()
 
     @Transactional
     fun remove(emojiId: Long, goalId: Long, emojiReactUserId: Long) {
@@ -68,10 +76,4 @@ class EmojiService(
             .groupBy { it.goal.id!! }
             .mapValues { ReactedEmojisResult.of(it.value, userId ?: -1) }
     }
-}
-
-inline fun ignoreDuplicatedReactedEmojiException(action: () -> Any) {
-    try {
-        action()
-    } catch (exception: DataIntegrityViolationException) {}
 }

--- a/backend/storage/db-core/src/main/kotlin/io/raemian/storage/db/core/emoji/ReactedEmojiRepository.kt
+++ b/backend/storage/db-core/src/main/kotlin/io/raemian/storage/db/core/emoji/ReactedEmojiRepository.kt
@@ -5,6 +5,9 @@ import io.raemian.storage.db.core.user.User
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface ReactedEmojiRepository : JpaRepository<ReactedEmoji, Long> {
+
+    fun existsByReactUserIdAndGoalIdAndEmojiId(reactUserId: Long, goalId: Long, emojiId: Long): Boolean
+
     fun findAllByGoal(goal: Goal): List<ReactedEmoji>
 
     fun findAllByGoalIdIn(goalIds: List<Long>): List<ReactedEmoji>


### PR DESCRIPTION
<!--
1. Jira
2. 어떤 작업을 했는지 : 간단하게 설명
3. 자세한 설명 : 필요하다면
4. 영향범위 : 영향받은 모듈
-->

## 📒 Issue
#253 

## 🎯 어떤 작업을 했는지
저장하기 전에 데이터가 있는지 확인하도록 변경했다.

## 📜 자세한 설명
### 원래 로직
원래는 DB제약조건으로 "따닥"이슈라 불리는 중복 반응 데이터 저장을 막으려 했다.
테이블에 (goal_id, user_id, emoji_id)로 Unique 조건을 걸어 알아서 DB에 저장되지 않게 하는 것이다.
이러면 DB Read없이 저장하니 좋다고 생각했다.

이후 발생하는 예외인 DataIntegrityViolationException를 catch로 잡아 무시하도록 설정했다.

그러나, 실제로는 Rollback이 일어났는데, Kotlin에서는 DataIntegrityViolationException를 Catch할 수 없고, Runtime Exception이 발생한다. 그리고, Transactional 안에서 Runtime Exception이 발생하면 해당 트랜잭션을 계속 사용할 수 없게 하고 Rollback한다.

### 선택한 방법

다양한 방법을 고려할 수 있지만, 일단 저장하기 전에 존재를 확인하게 했다. <br>
아마도 "따닥" 이슈가 발생하면 500에러가 발생할 것이다. 그렇다고 이거 떄문에 락을 거는건 또 과한것 같아서 더 알아봐야 할 것 같다.. 하지만, 일단 현재 아예 중복 등록 차제가 안되서 예외가 발생하기 때문에 이렇게 막아두려 한다.. <br> <br>


### 고려할 수 있는 방법들
1. Transactional을 Repository에 걸기 : 프로젝트 내의 컨벤션 일관성이 깨지기 때문에 정 방법이 없으면 선택할 듯 하다.
2. noRollbackFor 속성 사용 : 이게 정석일 듯 한데, Kotlin 코드에서는 DataIntegrityViolationException를 KClass로 변환할 수 없어서 등록이 어렵다. 더 자세한 이유를 찾다가 링크를 잃어버렸는데 Kotlin에서 Checked Exception을 없앤 것과 관련이 있었다. 일단 정석은 이쪽이기 때문에, 이쪽을 계속 찾아볼 것이다.. java로 작성하면 가능한데 이것만 자바로 짜는 것도 웃기다..
3. 예외를 catch하게 하는 방법을 찾아보기
4. 트랜잭션을 분리한다 : 트랜잭션을 분리하는 방법도 괜찮아 보이나, 구현 자체가 일단 저장만을 위한 새로운 클래스가 필요하게 되서 별로 선택하고 싶은 방법은 아니다... 그래도 선택지가 없으면 이렇게 해야 할지도 모른다..
5. 스레드를 분리한다 : 트랜잭션을 분리하는 방법 중 하나가 될 수 있으나, 자동 롤백을 막기 위한 방법으로는 의도가 너무 불순하다..

## 🌍 영향범위 (모듈)


---
Resolves: # See also: #
