### PR TITLE
[🛠️ Refactor] 이모지 응답시 고정된 순서로 내려주기

### DIFF
--- a/backend/application/api/src/main/kotlin/io/raemian/api/emoji/model/ReactedEmojisResult.kt
+++ b/backend/application/api/src/main/kotlin/io/raemian/api/emoji/model/ReactedEmojisResult.kt
@@ -34,6 +34,7 @@ data class ReactedEmojisResult(
                 .groupBy { it.emoji.id }
                 .mapValues { entry -> ReactedEmojiAndReactUsers.of(entry.value, userId) }
                 .values
+                .sortedBy { it.id }
                 .toList()
 
         private fun countTotalReactUser(reactedEmojiAndReactUsers: List<ReactedEmojiAndReactUsers>) =

--- a/backend/application/api/src/main/kotlin/io/raemian/api/emoji/service/EmojiService.kt
+++ b/backend/application/api/src/main/kotlin/io/raemian/api/emoji/service/EmojiService.kt
@@ -24,6 +24,7 @@ class EmojiService(
     @Transactional(readOnly = true)
     fun findAll(): List<EmojiResult> =
         emojiRepository.findAll()
+            .sortedBy { it.id }
             .map(EmojiResult::from)
 
     @Transactional(readOnly = true)

--- a/backend/application/api/src/main/kotlin/io/raemian/api/emoji/service/EmojiService.kt
+++ b/backend/application/api/src/main/kotlin/io/raemian/api/emoji/service/EmojiService.kt
@@ -24,7 +24,6 @@ class EmojiService(
     @Transactional(readOnly = true)
     fun findAll(): List<EmojiResult> =
         emojiRepository.findAll()
-            .sortedBy { it.id }
             .map(EmojiResult::from)
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
<!--
1. Jira
2. 어떤 작업을 했는지 : 간단하게 설명
3. 자세한 설명 : 필요하다면
4. 영향범위 : 영향받은 모듈
-->

## 📒 Issue

## 🎯 어떤 작업을 했는지
Goal에 달린 이모지 응답시 이모지 순서를 고정해 달라는 요청이 있어 고정하려 한다.
반응된 이모지 리스트를 만들 때, 정렬 과정 추가

## 📜 자세한 설명
Goal 이모지 응답시 List로 변경 전에 정렬하여 변경

---
Resolves: # See also: #
